### PR TITLE
[docs]: AI 설정 및 프로젝트 컨벤션 문서 추가

### DIFF
--- a/.ai/code_convention.md
+++ b/.ai/code_convention.md
@@ -1,0 +1,69 @@
+# 코드 컨벤션
+
+## 패키지 구조
+- 도메인 기반 패키지 구조를 사용한다.
+- 루트 패키지: `com.flover.flover_be`
+- 각 도메인 패키지 하위에 `controller`, `service`, `repository`, `domain`, `dto` 패키지를 둔다.
+
+```
+com.flover.flover_be
+├── user/
+│   ├── controller/
+│   ├── service/
+│   ├── repository/
+│   ├── domain/ ← Entity 클래스
+│   └── dto/
+├── order/
+│   ├── controller/
+│   ├── service/
+│   ├── repository/
+│   ├── domain/ 
+│   └── dto/
+└── global/
+    ├── exception/
+    └── response/
+```
+
+## DTO
+- Request/Response DTO는 Java Record로 작성한다.
+- DTO에 Jakarta Validation 어노테이션을 직접 선언한다.
+- 요청과 응답 DTO를 분리한다.
+- Inner class 패턴으로 관련 DTO를 그룹핑한다.
+
+```java
+public class UserDto {
+    public record Request(@NotBlank String name, @Email String email) {}
+    public record Response(Long id, String name, String email) {}
+}
+```
+
+## Entity
+- `@NoArgsConstructor(access = AccessLevel.PROTECTED)`를 사용한다.
+- 생성자는 정적 팩토리 메서드(`of`, `create`)로 대체한다.
+- 엔티티를 API 응답으로 직접 노출하지 않는다.
+
+## 빌더 패턴
+- 필드가 많거나 생성자가 복잡한 경우 빌더 패턴 사용을 고려한다.
+- 가독성과 유지보수를 위해 의미 있는 필드만 선택적으로 설정할 수 있도록 한다.
+- DTO 또는 테스트 객체 생성 시 적극적으로 활용한다.
+- 엔티티의 생성 규칙을 우회하는 무분별한 빌더 사용은 지양한다.
+
+## 예외 처리
+- 도메인별 커스텀 예외는 프로젝트 공통 예외 클래스인 `BusinessException`을 상속한다.
+- 예외 클래스는 HTTP 상태 코드와 메시지를 포함하도록 설계한다.
+- 예외 메시지는 사용자 친화적이고 구체적으로 작성한다.
+- `GlobalExceptionHandler`(`@RestControllerAdvice`)에서 모든 예외를 공통 처리한다.
+- 클라이언트 응답은 `ErrorResponse` DTO로 통일한다.
+
+## 네이밍
+- 서비스 메서드: 동사 + 목적어 (예: `createUser`, `findUserById`)
+- Boolean 반환 메서드: `is` / `has` / `can` 접두사 사용
+- 컬렉션 반환: 복수형 사용 (예: `findActiveUsers`)
+
+## 안티패턴 금지
+- Controller에서 Repository를 직접 호출하지 않는다.
+- `@Autowired` 필드 주입을 사용하지 않는다.
+- `Optional`을 필드나 메서드 파라미터 타입으로 사용하지 않는다.
+- 엔티티를 Controller 반환값으로 직접 사용하지 않는다.
+- 엔티티에 public setter를 사용하지 않는다.
+- 상태 변경은 의미 있는 도메인 메서드를 통해 수행한다. (예: changePassword)

--- a/.ai/skills.md
+++ b/.ai/skills.md
@@ -1,0 +1,21 @@
+# 기술 스택
+
+## Core
+- Java 21
+- Spring Boot 4.0.5
+- Spring Data JPA
+- Spring Web MVC
+- MySQL
+- Lombok
+- Gradle (Groovy DSL)
+
+## 테스트
+- JUnit 5
+- AssertJ
+- Mockito
+- Spring Boot Test
+
+## 주의 사항
+- `javax` 패키지 대신 `jakarta` 패키지를 사용한다.
+- `@Autowired` 필드 주입을 사용하지 않는다. 생성자 주입만 사용한다. (Lombok `@RequiredArgsConstructor` 활용)
+- 프로젝트에 없는 외부 라이브러리(QueryDSL, MapStruct, Security 등)는 임의로 추가하지 않는다.

--- a/.ai/test_convention.md
+++ b/.ai/test_convention.md
@@ -1,0 +1,49 @@
+# 테스트 컨벤션
+
+## 프레임워크
+- JUnit 5 + AssertJ
+- Mockito (단위 테스트)
+- `@SpringBootTest` (통합 테스트)
+
+## 테스트 구조
+- Given-When-Then 패턴을 따른다.
+- `@DisplayName`에 한글로 테스트 의도를 명시한다.
+- 메서드명은 영문 snake_case로 작성한다.
+
+```java
+@DisplayName("존재하지 않는 사용자 조회 시 예외가 발생한다")
+@Test
+void find_user_by_id_throws_exception_when_not_found() {
+    // given
+    Long userId = 999L;
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userService.findById(userId))
+        .isInstanceOf(UserNotFoundException.class);
+}
+```
+## 테스트
+- 단순 비즈니스 로직 검증은 Mockito 기반 단위 테스트를 우선한다.
+- Repository 계층 테스트는 필요 시 `@DataJpaTest`를 우선 고려한다.
+- 하나의 테스트는 하나의 행위/결과를 검증하는 데 집중한다.
+- 테스트 데이터는 각 테스트 내부에서 명확하게 준비한다.
+- 매직 넘버/하드코딩 문자열은 의미 있는 변수명으로 추출한다.
+- 테스트 메서드에서 다른 테스트 메서드에 의존하지 않는다.
+- 테스트 이름, DisplayName, 검증 내용을 통해 실패 원인을 쉽게 파악할 수 있도록 작성한다.
+- 테스트 커버리지는 높게 유지하되, 수치보다 핵심 비즈니스 로직 검증을 우선한다.
+- 의미 없는 테스트(예: Lombok 생성자, 단순 getter/setter)는 작성하지 않는다.
+
+## 단위 테스트
+- `@ExtendWith(MockitoExtension.class)` 사용
+- 의존성은 `@Mock` / `@InjectMocks`로 주입
+- Service 레이어를 중점적으로 단위 테스트한다.
+
+## 통합 테스트
+- `@SpringBootTest` + `@Transactional` 조합으로 DB 롤백을 보장한다.
+- 테스트용 프로퍼티는 `src/test/resources/application.properties`에 분리한다.
+- 통합 테스트가 꼭 필요한 경우에만 `@SpringBootTest`를 사용한다.
+
+## 안티패턴 금지
+- 프로덕션 코드를 테스트만을 위해 수정하지 않는다.
+- `@Autowired`로 구체 구현체를 직접 주입해 결합도를 높이지 않는다.

--- a/.ai/workflow.md
+++ b/.ai/workflow.md
@@ -1,0 +1,24 @@
+# 개발 워크플로우
+
+## 기능 개발 순서
+1. Domain Entity 정의 (`domain/`)
+2. Repository 인터페이스 작성 (`repository/`)
+3. Service 레이어 구현 (`service/`)
+4. DTO 작성 (`dto/` — Record 사용)
+5. Controller 구현 (`controller/`)
+6. 테스트 코드 작성 (단위 테스트 → 통합 테스트)
+
+## 브랜치 전략
+- `feature/{도메인}/{기능명}` 형식으로 브랜치를 생성한다.
+- 예: `feature/user/signup`, `feature/order/create`
+
+## 커밋 메시지
+- Conventional Commits를 따른다.
+- 접두사: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+- 형식: `[type]: 한글 설명`
+- 예: `[feat]: 회원 가입 API 구현`, `[fix]: 주문 조회 NPE 수정`
+
+## PR 규칙
+- PR 제목은 커밋 메시지 형식을 따른다.
+- 관련 이슈를 반드시 연결한다 (`close #이슈번호`).
+- 로컬 동작 확인 및 테스트 통과 후 PR을 올린다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+Before making changes in this repository, read and follow these project rules:
+
+- .ai/skills.md
+- .ai/code_convention.md
+- .ai/workflow.md
+- .ai/test_convention.md
+
+Treat those files as the source of truth for:
+- project stack
+- code conventions
+- workflow
+- test conventions
+
+If these rules conflict with a direct user request, ask for clarification.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with code in this repository.
+
+@.ai/skills.md
+@.ai/code_convention.md
+@.ai/workflow.md
+@.ai/test_convention.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,14 @@
+# GEMINI.md
+
+Before making changes in this repository, read:
+
+- .ai/skills.md
+- .ai/code_convention.md
+- .ai/workflow.md
+- .ai/test_convention.md
+
+Follow these files as the source of truth for:
+- project stack
+- code conventions
+- workflow
+- testing rules


### PR DESCRIPTION
## 관련 이슈
- close #1 

## 작업 내용
- 프로젝트 코드/테스트/워크플로우 컨벤션 문서 추가
- `.ai/` 폴더에 공통 규칙(스킬, 코드 컨벤션, 테스트 컨벤션, 워크플로우) 정리
- Claude, Codex, Gemini에서 공통 규칙을 참조할 수 있도록 설정 파일 추가 (CLAUDE.md, AGENTS.md, GEMINI.md)

## 테스트
- [x] 문서 작업으로 별도 실행 테스트 없음

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.