### PR TITLE
[feat]: 카카오 OAuth 로그인 및 JWT 액세스 토큰 발급 구현

### DIFF
--- a/.ai/code_convention.md
+++ b/.ai/code_convention.md
@@ -11,16 +11,18 @@ com.flover.flover_be
 │   ├── controller/
 │   ├── service/
 │   ├── repository/
-│   ├── domain/ ← Entity 클래스
+│   ├── domain/    ← Entity 클래스
+│   ├── exception/ ← 도메인 ErrorCode enum, 도메인 Exception 클래스
 │   └── dto/
 ├── order/
 │   ├── controller/
 │   ├── service/
 │   ├── repository/
-│   ├── domain/ 
+│   ├── domain/
+│   ├── exception/
 │   └── dto/
 └── global/
-    ├── exception/
+    ├── exception/ ← ErrorCode(interface), CommonErrorCode, BusinessException, GlobalExceptionHandler
     └── response/
 ```
 
@@ -49,16 +51,52 @@ public class UserDto {
 - 엔티티의 생성 규칙을 우회하는 무분별한 빌더 사용은 지양한다.
 
 ## 예외 처리
-- 도메인별 커스텀 예외는 프로젝트 공통 예외 클래스인 `BusinessException`을 상속한다.
-- 예외 클래스는 HTTP 상태 코드와 메시지를 포함하도록 설계한다.
-- 예외 메시지는 사용자 친화적이고 구체적으로 작성한다.
+- `ErrorCode`는 `global/exception/`에 **인터페이스**로 선언한다. (`getStatus()`, `getMessage()` 정의)
+- 에러 코드는 도메인별로 분리하여 각 도메인의 `exception/` 패키지에 enum으로 관리한다.
+  - 도메인 공통 에러: `global/exception/CommonErrorCode`
+  - 도메인별 에러: `{domain}/exception/{Domain}ErrorCode` (예: `user/exception/AuthErrorCode`)
+- 도메인별 커스텀 예외는 `BusinessException`을 상속하며 `ErrorCode`를 인자로 받는다.
+- 커스텀 예외 클래스는 해당 도메인의 `exception/` 하위에 위치한다. (`global/exception/`에 두지 않는다.)
 - `GlobalExceptionHandler`(`@RestControllerAdvice`)에서 모든 예외를 공통 처리한다.
-- 클라이언트 응답은 `ErrorResponse` DTO로 통일한다.
+- 에러 응답은 `ErrorResponse` DTO로 통일한다.
+
+```java
+// global: ErrorCode 인터페이스
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getMessage();
+}
+
+// global: 서버 공통 에러
+public enum CommonErrorCode implements ErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+}
+
+// user: 도메인 에러코드
+public enum AuthErrorCode implements ErrorCode {
+    KAKAO_TOKEN_FAILED(HttpStatus.UNAUTHORIZED, "카카오 토큰 발급에 실패했습니다.");
+}
+
+// user: 도메인 예외는 ErrorCode를 받아 부모에게 위임
+public class KakaoAuthException extends BusinessException {
+    public KakaoAuthException(ErrorCode errorCode) { super(errorCode); }
+}
+```
 
 ## 네이밍
 - 서비스 메서드: 동사 + 목적어 (예: `createUser`, `findUserById`)
 - Boolean 반환 메서드: `is` / `has` / `can` 접두사 사용
 - 컬렉션 반환: 복수형 사용 (예: `findActiveUsers`)
+
+## 환경변수 관리
+- DB 비밀번호, JWT secret, OAuth 키 등 민감한 설정값은 `.env` 파일에 관리한다.
+- `application.properties`에서 `${VAR_NAME}` 형식으로 참조한다.
+- `.env`는 `.gitignore`에 추가한다.
+
+## API 응답 형식
+- 성공 응답은 Controller에서 데이터를 직접 반환한다. (`ResponseEntity<T>` 또는 `T`)
+- 공통 래퍼(`ApiResponse<T>`)를 사용하지 않는다.
+- 에러 응답만 `ErrorResponse` DTO로 통일한다.
 
 ## 안티패턴 금지
 - Controller에서 Repository를 직접 호출하지 않는다.

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,12 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'

--- a/src/main/java/com/flover/flover_be/FloverBeApplication.java
+++ b/src/main/java/com/flover/flover_be/FloverBeApplication.java
@@ -2,8 +2,10 @@ package com.flover.flover_be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class FloverBeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/flover/flover_be/global/config/KakaoProperties.java
+++ b/src/main/java/com/flover/flover_be/global/config/KakaoProperties.java
@@ -1,0 +1,10 @@
+package com.flover.flover_be.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kakao")
+public record KakaoProperties(
+        String clientId,
+        String clientSecret,
+        String redirectUri
+) {}

--- a/src/main/java/com/flover/flover_be/global/config/RestClientConfig.java
+++ b/src/main/java/com/flover/flover_be/global/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.flover.flover_be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.create();
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/config/SwaggerConfig.java
+++ b/src/main/java/com/flover/flover_be/global/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.flover.flover_be.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Flover API")
+                        .version("v1.0")
+                        .description("Flover 서비스 API 문서"));
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/config/WebConfig.java
+++ b/src/main/java/com/flover/flover_be/global/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.flover.flover_be.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/exception/BusinessException.java
+++ b/src/main/java/com/flover/flover_be/global/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.flover.flover_be.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/flover/flover_be/global/exception/CommonErrorCode.java
@@ -1,0 +1,15 @@
+package com.flover.flover_be.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/flover/flover_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/flover/flover_be/global/exception/ErrorCode.java
@@ -1,0 +1,10 @@
+package com.flover.flover_be.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    HttpStatus getStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/flover/flover_be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flover/flover_be/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.flover.flover_be.global.exception;
+
+import com.flover.flover_be.global.response.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getMessage()));
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/jwt/JwtProvider.java
+++ b/src/main/java/com/flover/flover_be/global/jwt/JwtProvider.java
@@ -1,0 +1,34 @@
+package com.flover.flover_be.global.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey secretKey;
+    private final long expiration;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration}") long expiration
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expiration = expiration;
+    }
+
+    public String generateToken(Long userId) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/response/ErrorResponse.java
+++ b/src/main/java/com/flover/flover_be/global/response/ErrorResponse.java
@@ -1,0 +1,8 @@
+package com.flover.flover_be.global.response;
+
+public record ErrorResponse(int status, String message) {
+
+    public static ErrorResponse of(int status, String message) {
+        return new ErrorResponse(status, message);
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/controller/AuthController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.flover.flover_be.user.controller;
+
+import com.flover.flover_be.user.dto.AuthDto;
+import com.flover.flover_be.user.service.KakaoAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "카카오 OAuth 인증 API")
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final KakaoAuthService kakaoAuthService;
+
+    @Operation(summary = "카카오 로그인", description = "프론트에서 받은 인가 코드로 JWT 토큰 발급")
+    @PostMapping("/kakao/login")
+    public ResponseEntity<AuthDto.LoginResponse> kakaoLogin(
+            @RequestBody @Valid AuthDto.CallbackRequest request
+    ) {
+        AuthDto.LoginResponse response = kakaoAuthService.kakaoLogin(request.code());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/domain/User.java
+++ b/src/main/java/com/flover/flover_be/user/domain/User.java
@@ -1,0 +1,47 @@
+package com.flover.flover_be.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kakao_id", unique = true, nullable = false)
+    private Long kakaoId;
+
+    private String email;
+    private String nickname;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    public static User create(Long kakaoId, String email, String nickname, String profileImageUrl) {
+        User user = new User();
+        user.kakaoId = kakaoId;
+        user.email = email;
+        user.nickname = nickname;
+        user.profileImageUrl = profileImageUrl;
+        return user;
+    }
+
+    public void updateProfile(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/dto/AuthDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/AuthDto.java
@@ -1,0 +1,17 @@
+package com.flover.flover_be.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class AuthDto {
+
+    public record CallbackRequest(@NotBlank String code) {}
+
+    public record LoginResponse(
+            String accessToken,
+            String tokenType,
+            Long userId,
+            String nickname,
+            String email
+    ) {}
+
+}

--- a/src/main/java/com/flover/flover_be/user/dto/KakaoDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/KakaoDto.java
@@ -1,0 +1,28 @@
+package com.flover.flover_be.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KakaoDto {
+
+    public record TokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("token_type") String tokenType,
+            @JsonProperty("refresh_token") String refreshToken,
+            @JsonProperty("expires_in") Long expiresIn
+    ) {}
+
+    public record UserInfoResponse(
+            Long id,
+            @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+    ) {
+        public record KakaoAccount(
+                String email,
+                Profile profile
+        ) {
+            public record Profile(
+                    String nickname,
+                    @JsonProperty("profile_image_url") String profileImageUrl
+            ) {}
+        }
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/exception/AuthErrorCode.java
+++ b/src/main/java/com/flover/flover_be/user/exception/AuthErrorCode.java
@@ -1,0 +1,17 @@
+package com.flover.flover_be.user.exception;
+
+import com.flover.flover_be.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    KAKAO_TOKEN_FAILED(HttpStatus.UNAUTHORIZED, "카카오 토큰 발급에 실패했습니다."),
+    KAKAO_USER_INFO_FAILED(HttpStatus.UNAUTHORIZED, "카카오 사용자 정보 조회에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/flover/flover_be/user/exception/KakaoAuthException.java
+++ b/src/main/java/com/flover/flover_be/user/exception/KakaoAuthException.java
@@ -1,0 +1,11 @@
+package com.flover.flover_be.user.exception;
+
+import com.flover.flover_be.global.exception.BusinessException;
+import com.flover.flover_be.global.exception.ErrorCode;
+
+public class KakaoAuthException extends BusinessException {
+
+    public KakaoAuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/repository/UserRepository.java
+++ b/src/main/java/com/flover/flover_be/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.flover.flover_be.user.repository;
+
+import com.flover.flover_be.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByKakaoId(Long kakaoId);
+}

--- a/src/main/java/com/flover/flover_be/user/service/KakaoAuthService.java
+++ b/src/main/java/com/flover/flover_be/user/service/KakaoAuthService.java
@@ -1,0 +1,104 @@
+package com.flover.flover_be.user.service;
+
+import com.flover.flover_be.global.config.KakaoProperties;
+import com.flover.flover_be.global.jwt.JwtProvider;
+import com.flover.flover_be.user.domain.User;
+import com.flover.flover_be.user.dto.AuthDto;
+import com.flover.flover_be.user.dto.KakaoDto;
+import com.flover.flover_be.user.exception.AuthErrorCode;
+import com.flover.flover_be.user.exception.KakaoAuthException;
+import com.flover.flover_be.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+
+    private static final String KAKAO_AUTH_URL = "https://kauth.kakao.com";
+    private static final String KAKAO_API_URL = "https://kapi.kakao.com";
+
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+    private final RestClient restClient;
+    private final KakaoProperties kakaoProperties;
+
+    @Transactional
+    public AuthDto.LoginResponse kakaoLogin(String code) {
+        String kakaoAccessToken = getKakaoAccessToken(code);
+        KakaoDto.UserInfoResponse userInfo = getKakaoUserInfo(kakaoAccessToken);
+        User user = upsertUser(userInfo);
+        String jwtToken = jwtProvider.generateToken(user.getId());
+
+        return new AuthDto.LoginResponse(jwtToken, "Bearer", user.getId(), user.getNickname(), user.getEmail());
+    }
+
+    private String getKakaoAccessToken(String code) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoProperties.clientId());
+        params.add("client_secret", kakaoProperties.clientSecret());
+        params.add("redirect_uri", kakaoProperties.redirectUri());
+        params.add("code", code);
+
+        try {
+            KakaoDto.TokenResponse response = restClient.post()
+                    .uri(KAKAO_AUTH_URL + "/oauth/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(params)
+                    .retrieve()
+                    .body(KakaoDto.TokenResponse.class);
+
+            if (response == null || response.accessToken() == null) {
+                throw new KakaoAuthException(AuthErrorCode.KAKAO_TOKEN_FAILED);
+            }
+            return response.accessToken();
+        } catch (RestClientResponseException e) {
+            log.error("카카오 토큰 요청 실패 - status: {}, body: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new KakaoAuthException(AuthErrorCode.KAKAO_TOKEN_FAILED);
+        } catch (RestClientException e) {
+            log.error("카카오 토큰 요청 실패 - 네트워크 오류: {}", e.getMessage());
+            throw new KakaoAuthException(AuthErrorCode.KAKAO_TOKEN_FAILED);
+        }
+    }
+
+    private KakaoDto.UserInfoResponse getKakaoUserInfo(String accessToken) {
+        try {
+            KakaoDto.UserInfoResponse response = restClient.get()
+                    .uri(KAKAO_API_URL + "/v2/user/me")
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .body(KakaoDto.UserInfoResponse.class);
+
+            if (response == null) {
+                throw new KakaoAuthException(AuthErrorCode.KAKAO_USER_INFO_FAILED);
+            }
+            return response;
+        } catch (RestClientException e) {
+            throw new KakaoAuthException(AuthErrorCode.KAKAO_USER_INFO_FAILED);
+        }
+    }
+
+    private User upsertUser(KakaoDto.UserInfoResponse userInfo) {
+        KakaoDto.UserInfoResponse.KakaoAccount account = userInfo.kakaoAccount();
+        String email = account != null ? account.email() : null;
+        String nickname = (account != null && account.profile() != null) ? account.profile().nickname() : null;
+        String profileImageUrl = (account != null && account.profile() != null) ? account.profile().profileImageUrl() : null;
+
+        return userRepository.findByKakaoId(userInfo.id())
+                .map(user -> {
+                    user.updateProfile(nickname, profileImageUrl);
+                    return user;
+                })
+                .orElseGet(() -> userRepository.save(User.create(userInfo.id(), email, nickname, profileImageUrl)));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,20 @@
 spring.application.name=flover-be
+spring.config.import=optional:file:.env[.properties]
+
+# Database
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.show-sql=true
+
+# Kakao OAuth
+kakao.client-id=${KAKAO_CLIENT_ID}
+kakao.client-secret=${KAKAO_CLIENT_SECRET}
+kakao.redirect-uri=${KAKAO_REDIRECT_URI}
+
+# JWT
+jwt.secret=${JWT_SECRET}
+jwt.expiration=${JWT_EXPIRATION}

--- a/src/test/java/com/flover/flover_be/global/jwt/JwtProviderTest.java
+++ b/src/test/java/com/flover/flover_be/global/jwt/JwtProviderTest.java
@@ -1,0 +1,40 @@
+package com.flover.flover_be.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtProviderTest {
+
+    private static final String SECRET = "test-secret-key-must-be-at-least-32-bytes!!";
+    private static final long EXPIRATION = 3_600_000L;
+
+    private final JwtProvider jwtProvider = new JwtProvider(SECRET, EXPIRATION);
+
+    @Test
+    void generateToken_토큰_생성_성공() {
+        String token = jwtProvider.generateToken(1L);
+        assertThat(token).isNotBlank();
+    }
+
+    @Test
+    void generateToken_subject가_userId와_일치() {
+        SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+
+        String token = jwtProvider.generateToken(42L);
+
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        assertThat(claims.getSubject()).isEqualTo("42");
+    }
+}

--- a/src/test/java/com/flover/flover_be/user/domain/UserTest.java
+++ b/src/test/java/com/flover/flover_be/user/domain/UserTest.java
@@ -1,0 +1,29 @@
+package com.flover.flover_be.user.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    @Test
+    void create_필드_정상_초기화() {
+        User user = User.create(12345L, "test@test.com", "닉네임", "http://img.url");
+
+        assertThat(user.getKakaoId()).isEqualTo(12345L);
+        assertThat(user.getEmail()).isEqualTo("test@test.com");
+        assertThat(user.getNickname()).isEqualTo("닉네임");
+        assertThat(user.getProfileImageUrl()).isEqualTo("http://img.url");
+    }
+
+    @Test
+    void updateProfile_닉네임과_이미지_변경() {
+        User user = User.create(1L, "a@b.com", "기존닉네임", "old.jpg");
+
+        user.updateProfile("새닉네임", "new.jpg");
+
+        assertThat(user.getNickname()).isEqualTo("새닉네임");
+        assertThat(user.getProfileImageUrl()).isEqualTo("new.jpg");
+    }
+
+}

--- a/src/test/java/com/flover/flover_be/user/service/KakaoAuthServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/KakaoAuthServiceTest.java
@@ -1,0 +1,119 @@
+package com.flover.flover_be.user.service;
+
+import com.flover.flover_be.global.config.KakaoProperties;
+import com.flover.flover_be.global.jwt.JwtProvider;
+import com.flover.flover_be.user.domain.User;
+import com.flover.flover_be.user.dto.AuthDto;
+import com.flover.flover_be.user.dto.KakaoDto;
+import com.flover.flover_be.user.exception.KakaoAuthException;
+import com.flover.flover_be.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class KakaoAuthServiceTest {
+
+    @Mock private RestClient restClient;
+    @Mock private UserRepository userRepository;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private KakaoProperties kakaoProperties;
+
+    @InjectMocks
+    private KakaoAuthService kakaoAuthService;
+
+    private RestClient.RequestBodyUriSpec postUriSpec;
+    private RestClient.RequestBodySpec postBodySpec;
+    private RestClient.ResponseSpec postResponseSpec;
+
+    private RestClient.RequestHeadersUriSpec getUriSpec;
+    private RestClient.RequestHeadersSpec getHeadersSpec;
+    private RestClient.ResponseSpec getResponseSpec;
+
+    @BeforeEach
+    void setUp() {
+        postUriSpec = mock(RestClient.RequestBodyUriSpec.class);
+        postBodySpec = mock(RestClient.RequestBodySpec.class);
+        postResponseSpec = mock(RestClient.ResponseSpec.class);
+
+        getUriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        getHeadersSpec = mock(RestClient.RequestHeadersSpec.class);
+        getResponseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.post()).thenReturn(postUriSpec);
+        when(postUriSpec.uri(anyString())).thenReturn(postBodySpec);
+        when(postBodySpec.contentType(any())).thenReturn(postBodySpec);
+        doReturn(postBodySpec).when(postBodySpec).body(any(Object.class));
+        when(postBodySpec.retrieve()).thenReturn(postResponseSpec);
+
+        when(restClient.get()).thenReturn(getUriSpec);
+        when(getUriSpec.uri(anyString())).thenReturn(getHeadersSpec);
+        when(getHeadersSpec.header(anyString(), anyString())).thenReturn(getHeadersSpec);
+        when(getHeadersSpec.retrieve()).thenReturn(getResponseSpec);
+    }
+
+    private KakaoDto.UserInfoResponse buildUserInfo(Long id, String email, String nickname) {
+        var profile = new KakaoDto.UserInfoResponse.KakaoAccount.Profile(nickname, "http://img.url");
+        var account = new KakaoDto.UserInfoResponse.KakaoAccount(email, profile);
+        return new KakaoDto.UserInfoResponse(id, account);
+    }
+
+    @Test
+    void 신규_유저면_save_호출() {
+        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com", "홍길동");
+        User saved = User.create(999L, "user@test.com", "홍길동", "http://img.url");
+
+        when(postResponseSpec.body(KakaoDto.TokenResponse.class))
+                .thenReturn(new KakaoDto.TokenResponse("kakao-token", "Bearer", "refresh", 3600L));
+        when(getResponseSpec.body(KakaoDto.UserInfoResponse.class)).thenReturn(userInfo);
+        when(userRepository.findByKakaoId(999L)).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenReturn(saved);
+        when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
+
+        AuthDto.LoginResponse result = kakaoAuthService.kakaoLogin("auth-code");
+
+        assertThat(result.accessToken()).isEqualTo("jwt-token");
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void 기존_유저면_save_없이_프로필_업데이트() {
+        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com", "새닉네임");
+        User existing = User.create(999L, "user@test.com", "기존닉네임", "old.jpg");
+
+        when(postResponseSpec.body(KakaoDto.TokenResponse.class))
+                .thenReturn(new KakaoDto.TokenResponse("kakao-token", "Bearer", "refresh", 3600L));
+        when(getResponseSpec.body(KakaoDto.UserInfoResponse.class)).thenReturn(userInfo);
+        when(userRepository.findByKakaoId(999L)).thenReturn(Optional.of(existing));
+        when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
+
+        kakaoAuthService.kakaoLogin("auth-code");
+
+        assertThat(existing.getNickname()).isEqualTo("새닉네임");
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void 카카오_토큰_실패시_KakaoAuthException_발생() {
+        when(postResponseSpec.body(KakaoDto.TokenResponse.class))
+                .thenThrow(mock(RestClientResponseException.class));
+
+        assertThatThrownBy(() -> kakaoAuthService.kakaoLogin("bad-code"))
+                .isInstanceOf(KakaoAuthException.class);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #3 

## 작업 내용
- 카카오 OAuth 인가 코드 기반 소셜 로그인 기능 구현
- 카카오 access token 발급 및 사용자 정보 조회 (이메일, 닉네임, 프로필 이미지)
- 사용자 upsert 처리 (신규 가입 / 기존 사용자 프로필 업데이트)
- JWT access token 발급 로직 구현 (refresh token은 추후 구현 예정)
- 전역 예외 처리 구조 설계 (ErrorCode, BusinessException, GlobalExceptionHandler)
- Swagger UI, CORS, RestClient 설정 추가

## 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 테스트 코드 작성 완료

## 체크리스트
- [x] 관련 없는 변경 사항 없음
- [x] 코드 및 기능 자체 검토 완료
- [x] 리뷰어가 이해할 수 있도록 작성

## reference
프론트 간단히 만들어서 테스트 추가적으로 완료했습니다.
<img width="612" height="417" alt="image" src="https://github.com/user-attachments/assets/134c2351-418f-49f2-ae52-5e9eb31a3a5c" />
<img width="608" height="693" alt="image" src="https://github.com/user-attachments/assets/f2784b32-97a3-4942-ba58-ca6e4eea9953" />
<img width="572" height="532" alt="image" src="https://github.com/user-attachments/assets/175b0adf-d1ef-477b-be47-56cf5c1028b8" />

