### PR TITLE
[feat]: JWT 인증 인프라 구축 및 닉네임 자동 생성·수정 API 구현

### DIFF
--- a/src/main/java/com/flover/flover_be/global/auth/AuthErrorCode.java
+++ b/src/main/java/com/flover/flover_be/global/auth/AuthErrorCode.java
@@ -1,0 +1,17 @@
+package com.flover.flover_be.global.auth;
+
+import com.flover.flover_be.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "인증 토큰이 없습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/flover/flover_be/global/auth/AuthException.java
+++ b/src/main/java/com/flover/flover_be/global/auth/AuthException.java
@@ -1,0 +1,11 @@
+package com.flover.flover_be.global.auth;
+
+import com.flover.flover_be.global.exception.BusinessException;
+import com.flover.flover_be.global.exception.ErrorCode;
+
+public class AuthException extends BusinessException {
+
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/flover/flover_be/global/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.flover.flover_be.global.auth;
+
+import com.flover.flover_be.global.exception.ErrorCode;
+import com.flover.flover_be.global.jwt.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String USER_ID_ATTRIBUTE = "userId";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = extractToken(request);
+        if (StringUtils.hasText(token)) {
+            try {
+                Long userId = jwtProvider.getUserId(token);
+                request.setAttribute(USER_ID_ATTRIBUTE, userId);
+            } catch (AuthException e) {
+                sendErrorResponse(response, e.getErrorCode());
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String bearer = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearer) && bearer.startsWith(BEARER_PREFIX)) {
+            return bearer.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(
+                String.format("{\"status\":%d,\"message\":\"%s\"}", errorCode.getStatus().value(), errorCode.getMessage())
+        );
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/flover/flover_be/global/auth/JwtAuthenticationFilter.java
@@ -1,7 +1,9 @@
 package com.flover.flover_be.global.auth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flover.flover_be.global.exception.ErrorCode;
 import com.flover.flover_be.global.jwt.JwtProvider;
+import com.flover.flover_be.global.response.ErrorResponse;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,6 +24,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -51,7 +54,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         response.setStatus(errorCode.getStatus().value());
         response.setContentType("application/json;charset=UTF-8");
         response.getWriter().write(
-                String.format("{\"status\":%d,\"message\":\"%s\"}", errorCode.getStatus().value(), errorCode.getMessage())
+                objectMapper.writeValueAsString(
+                        ErrorResponse.of(errorCode.getStatus().value(), errorCode.getMessage())
+                )
         );
     }
 }

--- a/src/main/java/com/flover/flover_be/global/auth/LoginUserId.java
+++ b/src/main/java/com/flover/flover_be/global/auth/LoginUserId.java
@@ -1,0 +1,9 @@
+package com.flover.flover_be.global.auth;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface LoginUserId {
+}

--- a/src/main/java/com/flover/flover_be/global/auth/LoginUserIdArgumentResolver.java
+++ b/src/main/java/com/flover/flover_be/global/auth/LoginUserIdArgumentResolver.java
@@ -1,0 +1,30 @@
+package com.flover.flover_be.global.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUserId.class)
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Long userId = (Long) request.getAttribute(JwtAuthenticationFilter.USER_ID_ATTRIBUTE);
+        if (userId == null) {
+            throw new AuthException(AuthErrorCode.MISSING_TOKEN);
+        }
+        return userId;
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/config/WebConfig.java
+++ b/src/main/java/com/flover/flover_be/global/config/WebConfig.java
@@ -1,11 +1,19 @@
 package com.flover.flover_be.global.config;
 
+import com.flover.flover_be.global.auth.LoginUserIdArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginUserIdArgumentResolver loginUserIdArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -14,5 +22,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserIdArgumentResolver);
     }
 }

--- a/src/main/java/com/flover/flover_be/global/config/WebConfig.java
+++ b/src/main/java/com/flover/flover_be/global/config/WebConfig.java
@@ -1,7 +1,9 @@
 package com.flover.flover_be.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flover.flover_be.global.auth.LoginUserIdArgumentResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -27,5 +29,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginUserIdArgumentResolver);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 }

--- a/src/main/java/com/flover/flover_be/global/jwt/JwtProvider.java
+++ b/src/main/java/com/flover/flover_be/global/jwt/JwtProvider.java
@@ -1,5 +1,8 @@
 package com.flover.flover_be.global.jwt;
 
+import com.flover.flover_be.global.auth.AuthErrorCode;
+import com.flover.flover_be.global.auth.AuthException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,5 +33,19 @@ public class JwtProvider {
                 .expiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(secretKey)
                 .compact();
+    }
+
+    public Long getUserId(String token) {
+        try {
+            String subject = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getSubject();
+            return Long.valueOf(subject);
+        } catch (JwtException e) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
     }
 }

--- a/src/main/java/com/flover/flover_be/global/jwt/JwtProvider.java
+++ b/src/main/java/com/flover/flover_be/global/jwt/JwtProvider.java
@@ -44,7 +44,7 @@ public class JwtProvider {
                     .getPayload()
                     .getSubject();
             return Long.valueOf(subject);
-        } catch (JwtException e) {
+        } catch (JwtException | NumberFormatException e) {
             throw new AuthException(AuthErrorCode.INVALID_TOKEN);
         }
     }

--- a/src/main/java/com/flover/flover_be/user/controller/UserController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.flover.flover_be.user.controller;
+
+import com.flover.flover_be.global.auth.LoginUserId;
+import com.flover.flover_be.user.dto.UserDto;
+import com.flover.flover_be.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "User", description = "사용자 API")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "닉네임 수정", description = "사용자 닉네임 변경")
+    @PutMapping("/me/nickname")
+    public ResponseEntity<UserDto.NicknameResponse> updateNickname(
+            @LoginUserId Long userId,
+            @RequestBody @Valid UserDto.NicknameRequest request
+    ) {
+        return ResponseEntity.ok(userService.updateNickname(userId, request.nickname()));
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/domain/User.java
+++ b/src/main/java/com/flover/flover_be/user/domain/User.java
@@ -44,4 +44,8 @@ public class User {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/flover/flover_be/user/dto/UserDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/UserDto.java
@@ -1,0 +1,10 @@
+package com.flover.flover_be.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class UserDto {
+
+    public record NicknameRequest(@NotBlank String nickname) {}
+
+    public record NicknameResponse(Long userId, String nickname) {}
+}

--- a/src/main/java/com/flover/flover_be/user/exception/UserErrorCode.java
+++ b/src/main/java/com/flover/flover_be/user/exception/UserErrorCode.java
@@ -1,0 +1,17 @@
+package com.flover.flover_be.user.exception;
+
+import com.flover.flover_be.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    NICKNAME_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/flover/flover_be/user/exception/UserException.java
+++ b/src/main/java/com/flover/flover_be/user/exception/UserException.java
@@ -1,0 +1,11 @@
+package com.flover.flover_be.user.exception;
+
+import com.flover.flover_be.global.exception.BusinessException;
+import com.flover.flover_be.global.exception.ErrorCode;
+
+public class UserException extends BusinessException {
+
+    public UserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/repository/UserRepository.java
+++ b/src/main/java/com/flover/flover_be/user/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByKakaoId(Long kakaoId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/flover/flover_be/user/service/KakaoAuthService.java
+++ b/src/main/java/com/flover/flover_be/user/service/KakaoAuthService.java
@@ -19,6 +19,8 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 
+import java.util.Random;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -91,14 +93,21 @@ public class KakaoAuthService {
     private User upsertUser(KakaoDto.UserInfoResponse userInfo) {
         KakaoDto.UserInfoResponse.KakaoAccount account = userInfo.kakaoAccount();
         String email = account != null ? account.email() : null;
-        String nickname = (account != null && account.profile() != null) ? account.profile().nickname() : null;
-        String profileImageUrl = (account != null && account.profile() != null) ? account.profile().profileImageUrl() : null;
 
         return userRepository.findByKakaoId(userInfo.id())
-                .map(user -> {
-                    user.updateProfile(nickname, profileImageUrl);
-                    return user;
-                })
-                .orElseGet(() -> userRepository.save(User.create(userInfo.id(), email, nickname, profileImageUrl)));
+                .orElseGet(() -> {
+                    String defaultNickname = generateDefaultNickname();
+                    return userRepository.save(User.create(userInfo.id(), email, defaultNickname, null));
+                });
+    }
+
+    private String generateDefaultNickname() {
+        Random random = new Random();
+        String nickname;
+        do {
+            int suffix = 100000 + random.nextInt(900000);
+            nickname = "플러버" + suffix;
+        } while (userRepository.existsByNickname(nickname));
+        return nickname;
     }
 }

--- a/src/main/java/com/flover/flover_be/user/service/KakaoAuthService.java
+++ b/src/main/java/com/flover/flover_be/user/service/KakaoAuthService.java
@@ -19,7 +19,7 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
 @Service
@@ -102,10 +102,9 @@ public class KakaoAuthService {
     }
 
     private String generateDefaultNickname() {
-        Random random = new Random();
         String nickname;
         do {
-            int suffix = 100000 + random.nextInt(900000);
+            int suffix = ThreadLocalRandom.current().nextInt(100000, 1000000);
             nickname = "플러버" + suffix;
         } while (userRepository.existsByNickname(nickname));
         return nickname;

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -1,0 +1,30 @@
+package com.flover.flover_be.user.service;
+
+import com.flover.flover_be.user.domain.User;
+import com.flover.flover_be.user.dto.UserDto;
+import com.flover.flover_be.user.exception.UserErrorCode;
+import com.flover.flover_be.user.exception.UserException;
+import com.flover.flover_be.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserDto.NicknameResponse updateNickname(Long userId, String nickname) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        if (!nickname.equals(user.getNickname()) && userRepository.existsByNickname(nickname)) {
+            throw new UserException(UserErrorCode.NICKNAME_ALREADY_USED);
+        }
+
+        user.updateNickname(nickname);
+        return new UserDto.NicknameResponse(user.getId(), user.getNickname());
+    }
+}

--- a/src/test/java/com/flover/flover_be/global/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/flover/flover_be/global/auth/JwtAuthenticationFilterTest.java
@@ -1,0 +1,79 @@
+package com.flover.flover_be.global.auth;
+
+import com.flover.flover_be.global.jwt.JwtProvider;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock private JwtProvider jwtProvider;
+    @InjectMocks private JwtAuthenticationFilter filter;
+
+    @DisplayName("유효한 토큰이면 userId가 request attribute에 저장된다")
+    @Test
+    void valid_token_saves_userId_attribute() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer valid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+
+        given(jwtProvider.getUserId("valid-token")).willReturn(1L);
+
+        // when
+        filter.doFilter(request, response, filterChain);
+
+        // then
+        assertThat(request.getAttribute(JwtAuthenticationFilter.USER_ID_ATTRIBUTE)).isEqualTo(1L);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @DisplayName("토큰이 없으면 attribute 없이 다음 필터로 넘어간다")
+    @Test
+    void no_token_passes_through() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+
+        // when
+        filter.doFilter(request, response, filterChain);
+
+        // then
+        assertThat(request.getAttribute(JwtAuthenticationFilter.USER_ID_ATTRIBUTE)).isNull();
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @DisplayName("유효하지 않은 토큰이면 401을 반환하고 다음 필터로 넘어가지 않는다")
+    @Test
+    void invalid_token_returns_401() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+
+        given(jwtProvider.getUserId("invalid-token"))
+                .willThrow(new AuthException(AuthErrorCode.INVALID_TOKEN));
+
+        // when
+        filter.doFilter(request, response, filterChain);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(401);
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+}

--- a/src/test/java/com/flover/flover_be/global/auth/LoginUserIdArgumentResolverTest.java
+++ b/src/test/java/com/flover/flover_be/global/auth/LoginUserIdArgumentResolverTest.java
@@ -1,0 +1,69 @@
+package com.flover.flover_be.global.auth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class LoginUserIdArgumentResolverTest {
+
+    private final LoginUserIdArgumentResolver resolver = new LoginUserIdArgumentResolver();
+
+    @DisplayName("@LoginUserId 어노테이션과 Long 타입 파라미터를 지원한다")
+    @Test
+    void supports_loginUserId_annotation_with_long_type() {
+        // given
+        MethodParameter parameter = mock(MethodParameter.class);
+        given(parameter.hasParameterAnnotation(LoginUserId.class)).willReturn(true);
+        given(parameter.getParameterType()).willReturn((Class) Long.class);
+
+        // when & then
+        assertThat(resolver.supportsParameter(parameter)).isTrue();
+    }
+
+    @DisplayName("@LoginUserId 어노테이션이 없으면 지원하지 않는다")
+    @Test
+    void not_supports_without_annotation() {
+        // given
+        MethodParameter parameter = mock(MethodParameter.class);
+        given(parameter.hasParameterAnnotation(LoginUserId.class)).willReturn(false);
+
+        // when & then
+        assertThat(resolver.supportsParameter(parameter)).isFalse();
+    }
+
+    @DisplayName("request attribute에 userId가 있으면 반환한다")
+    @Test
+    void resolves_userId_from_attribute() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(JwtAuthenticationFilter.USER_ID_ATTRIBUTE, 1L);
+        NativeWebRequest webRequest = mock(NativeWebRequest.class);
+        given(webRequest.getNativeRequest()).willReturn(request);
+
+        // when
+        Object result = resolver.resolveArgument(mock(MethodParameter.class), null, webRequest, null);
+
+        // then
+        assertThat(result).isEqualTo(1L);
+    }
+
+    @DisplayName("request attribute에 userId가 없으면 AuthException이 발생한다")
+    @Test
+    void throws_auth_exception_when_no_userId() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        NativeWebRequest webRequest = mock(NativeWebRequest.class);
+        given(webRequest.getNativeRequest()).willReturn(request);
+
+        // when & then
+        assertThatThrownBy(() -> resolver.resolveArgument(mock(MethodParameter.class), null, webRequest, null))
+                .isInstanceOf(AuthException.class);
+    }
+}

--- a/src/test/java/com/flover/flover_be/global/jwt/JwtProviderTest.java
+++ b/src/test/java/com/flover/flover_be/global/jwt/JwtProviderTest.java
@@ -1,5 +1,6 @@
 package com.flover.flover_be.global.jwt;
 
+import com.flover.flover_be.global.auth.AuthException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -7,8 +8,10 @@ import org.junit.jupiter.api.Test;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class JwtProviderTest {
 
@@ -36,5 +39,33 @@ class JwtProviderTest {
                 .getPayload();
 
         assertThat(claims.getSubject()).isEqualTo("42");
+    }
+
+    @Test
+    void getUserId_유효한_토큰에서_userId_반환() {
+        String token = jwtProvider.generateToken(42L);
+
+        assertThat(jwtProvider.getUserId(token)).isEqualTo(42L);
+    }
+
+    @Test
+    void getUserId_만료된_토큰이면_AuthException_발생() {
+        SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        String expiredToken = Jwts.builder()
+                .subject("1")
+                .expiration(new Date(System.currentTimeMillis() - 1000))
+                .signWith(key)
+                .compact();
+
+        assertThatThrownBy(() -> jwtProvider.getUserId(expiredToken))
+                .isInstanceOf(AuthException.class);
+    }
+
+    @Test
+    void getUserId_변조된_토큰이면_AuthException_발생() {
+        String token = jwtProvider.generateToken(1L);
+
+        assertThatThrownBy(() -> jwtProvider.getUserId(token + "tampered"))
+                .isInstanceOf(AuthException.class);
     }
 }

--- a/src/test/java/com/flover/flover_be/user/domain/UserTest.java
+++ b/src/test/java/com/flover/flover_be/user/domain/UserTest.java
@@ -26,4 +26,13 @@ class UserTest {
         assertThat(user.getProfileImageUrl()).isEqualTo("new.jpg");
     }
 
+    @Test
+    void updateNickname_닉네임_변경() {
+        User user = User.create(1L, "a@b.com", "기존닉네임", null);
+
+        user.updateNickname("새닉네임");
+
+        assertThat(user.getNickname()).isEqualTo("새닉네임");
+    }
+
 }

--- a/src/test/java/com/flover/flover_be/user/service/KakaoAuthServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/KakaoAuthServiceTest.java
@@ -18,6 +18,8 @@ import org.mockito.quality.Strictness;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
+import org.mockito.ArgumentCaptor;
+
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -76,12 +78,13 @@ class KakaoAuthServiceTest {
     @Test
     void 신규_유저면_save_호출() {
         KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com", "홍길동");
-        User saved = User.create(999L, "user@test.com", "홍길동", "http://img.url");
+        User saved = User.create(999L, "user@test.com", "플러버123456", null);
 
         when(postResponseSpec.body(KakaoDto.TokenResponse.class))
                 .thenReturn(new KakaoDto.TokenResponse("kakao-token", "Bearer", "refresh", 3600L));
         when(getResponseSpec.body(KakaoDto.UserInfoResponse.class)).thenReturn(userInfo);
         when(userRepository.findByKakaoId(999L)).thenReturn(Optional.empty());
+        when(userRepository.existsByNickname(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenReturn(saved);
         when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
 
@@ -92,7 +95,43 @@ class KakaoAuthServiceTest {
     }
 
     @Test
-    void 기존_유저면_save_없이_프로필_업데이트() {
+    void 신규_유저_기본_닉네임이_플러버_형식으로_생성됨() {
+        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com", "홍길동");
+
+        when(postResponseSpec.body(KakaoDto.TokenResponse.class))
+                .thenReturn(new KakaoDto.TokenResponse("kakao-token", "Bearer", "refresh", 3600L));
+        when(getResponseSpec.body(KakaoDto.UserInfoResponse.class)).thenReturn(userInfo);
+        when(userRepository.findByKakaoId(999L)).thenReturn(Optional.empty());
+        when(userRepository.existsByNickname(anyString())).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
+
+        kakaoAuthService.kakaoLogin("auth-code");
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getNickname()).matches("플러버\\d{6}");
+    }
+
+    @Test
+    void 닉네임_중복시_재생성() {
+        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com", "홍길동");
+
+        when(postResponseSpec.body(KakaoDto.TokenResponse.class))
+                .thenReturn(new KakaoDto.TokenResponse("kakao-token", "Bearer", "refresh", 3600L));
+        when(getResponseSpec.body(KakaoDto.UserInfoResponse.class)).thenReturn(userInfo);
+        when(userRepository.findByKakaoId(999L)).thenReturn(Optional.empty());
+        when(userRepository.existsByNickname(anyString())).thenReturn(true).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
+
+        kakaoAuthService.kakaoLogin("auth-code");
+
+        verify(userRepository, times(2)).existsByNickname(anyString());
+    }
+
+    @Test
+    void 기존_유저면_save_호출_안하고_닉네임_유지() {
         KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com", "새닉네임");
         User existing = User.create(999L, "user@test.com", "기존닉네임", "old.jpg");
 
@@ -104,7 +143,7 @@ class KakaoAuthServiceTest {
 
         kakaoAuthService.kakaoLogin("auth-code");
 
-        assertThat(existing.getNickname()).isEqualTo("새닉네임");
+        assertThat(existing.getNickname()).isEqualTo("기존닉네임");
         verify(userRepository, never()).save(any());
     }
 

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -1,0 +1,91 @@
+package com.flover.flover_be.user.service;
+
+import com.flover.flover_be.user.domain.User;
+import com.flover.flover_be.user.dto.UserDto;
+import com.flover.flover_be.user.exception.UserException;
+import com.flover.flover_be.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @InjectMocks private UserService userService;
+
+    @DisplayName("닉네임을 정상적으로 변경한다")
+    @Test
+    void update_nickname_성공() {
+        // given
+        Long userId = 1L;
+        String newNickname = "새닉네임";
+        User user = User.create(1L, "test@test.com", "기존닉네임", null);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.existsByNickname(newNickname)).willReturn(false);
+
+        // when
+        UserDto.NicknameResponse result = userService.updateNickname(userId, newNickname);
+
+        // then
+        assertThat(result.nickname()).isEqualTo(newNickname);
+    }
+
+    @DisplayName("존재하지 않는 유저의 닉네임 변경 시 예외가 발생한다")
+    @Test
+    void update_nickname_유저없음_예외() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateNickname(1L, "새닉네임"))
+                .isInstanceOf(UserException.class);
+    }
+
+    @DisplayName("이미 사용 중인 닉네임으로 변경 시 예외가 발생한다")
+    @Test
+    void update_nickname_중복_닉네임_예외() {
+        // given
+        Long userId = 1L;
+        String duplicateNickname = "중복닉네임";
+        User user = User.create(1L, "test@test.com", "기존닉네임", null);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.existsByNickname(duplicateNickname)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateNickname(userId, duplicateNickname))
+                .isInstanceOf(UserException.class);
+    }
+
+    @DisplayName("현재 닉네임과 동일한 닉네임으로 변경 시 중복 검사를 건너뛴다")
+    @Test
+    void update_nickname_같은_닉네임이면_중복_검사_건너뜀() {
+        // given
+        Long userId = 1L;
+        String sameNickname = "기존닉네임";
+        User user = User.create(1L, "test@test.com", sameNickname, null);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        userService.updateNickname(userId, sameNickname);
+
+        // then
+        verify(userRepository, never()).existsByNickname(anyString());
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #5

## 작업 내용
- 카카오 로그인 시 신규 사용자에게 `플러버 + 6자리 난수` 형식의 기본 닉네임 자동 부여
- 기존 사용자는 로그인 시 기존 닉네임 유지 (카카오 프로필과 무관하게 앱 닉네임 독립 관리)
- `JwtAuthenticationFilter` 구현  
  - 모든 요청에서 JWT 토큰 파싱 후 userId를 request attribute에 저장
- `@LoginUserId` ArgumentResolver 구현  
  - JWT에서 userId를 컨트롤러 파라미터에 직접 주입
- `PUT /api/users/me/nickname` 닉네임 수정 API 구현

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.