### PR TITLE
[feat]: S3 Presigned URL 업로드 구조 및 프로필 이미지 업로드 API 구현

### DIFF
--- a/.ai/code_convention.md
+++ b/.ai/code_convention.md
@@ -98,6 +98,15 @@ public class KakaoAuthException extends BusinessException {
 - 공통 래퍼(`ApiResponse<T>`)를 사용하지 않는다.
 - 에러 응답만 `ErrorResponse` DTO로 통일한다.
 
+## S3 파일 업로드 패턴
+- 파일 업로드는 **Presigned URL** 방식을 사용한다. 서버가 파일을 직접 받지 않는다.
+  1. 클라이언트가 `GET /upload-url?contentType=image/png` 요청 → 서버가 S3 Presigned PUT URL + 최종 imageUrl 반환
+  2. 클라이언트가 Presigned URL로 S3에 직접 PUT 업로드
+  3. 클라이언트가 `PUT /profile-image` with `{ imageUrl }` → 서버가 DB에 URL 저장
+- Presigned URL 유효 시간은 10분으로 설정한다.
+- 허용 Content-Type은 서버에서 검증하며, Presigned URL 서명 시에도 Content-Type을 고정한다.
+- `S3Client`와 `S3Presigner` 모두 `AwsCredentialsProvider` Bean을 공유한다.
+
 ## 안티패턴 금지
 - Controller에서 Repository를 직접 호출하지 않는다.
 - `@Autowired` 필드 주입을 사용하지 않는다.
@@ -105,3 +114,4 @@ public class KakaoAuthException extends BusinessException {
 - 엔티티를 Controller 반환값으로 직접 사용하지 않는다.
 - 엔티티에 public setter를 사용하지 않는다.
 - 상태 변경은 의미 있는 도메인 메서드를 통해 수행한다. (예: changePassword)
+- `IllegalArgumentException`, `IllegalStateException` 등 표준 Java 예외를 도메인 로직에서 직접 던지지 않는다. 도메인 엔티티 내부에서도 커스텀 `BusinessException` 서브클래스를 사용한다.

--- a/.ai/skills.md
+++ b/.ai/skills.md
@@ -8,6 +8,7 @@
 - MySQL
 - Lombok
 - Gradle (Groovy DSL)
+- AWS SDK v2 (`software.amazon.awssdk:s3`) — S3 파일 저장, Presigned URL 발급
 
 ## 테스트
 - JUnit 5

--- a/.ai/test_convention.md
+++ b/.ai/test_convention.md
@@ -39,6 +39,12 @@ void find_user_by_id_throws_exception_when_not_found() {
 - 의존성은 `@Mock` / `@InjectMocks`로 주입
 - Service 레이어를 중점적으로 단위 테스트한다.
 
+### `@Mock` vs `@Spy`
+- `@Mock`: 완전한 가짜 객체. 모든 메서드가 기본값(null, 0, false)을 반환하며 실제 로직은 실행되지 않는다.
+- `@Spy`: 실제 객체를 감싼다. 명시적으로 stub하지 않은 메서드는 실제 구현이 그대로 실행된다.
+- **`@Spy`를 사용하는 경우**: 의존 객체의 실제 동작이 테스트 검증에 필요할 때. 예: `ObjectMapper`를 `@Mock`으로 두면 JSON 직렬화가 null을 반환해 필터 에러 응답 테스트가 의미 없어진다.
+- 원칙: 의존성을 완전히 격리하고 싶으면 `@Mock`, 실제 동작이 필요하면 `@Spy`.
+
 ## 통합 테스트
 - `@SpringBootTest` + `@Transactional` 조합으로 DB 롤백을 보장한다.
 - 테스트용 프로퍼티는 `src/test/resources/application.properties`에 분리한다.

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	implementation 'software.amazon.awssdk:s3:2.25.70'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/flover/flover_be/global/config/AwsS3Config.java
+++ b/src/main/java/com/flover/flover_be/global/config/AwsS3Config.java
@@ -1,0 +1,50 @@
+package com.flover.flover_be.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+    @Bean
+    public AwsCredentialsProvider awsCredentialsProvider(
+            @Value("${aws.credentials.access-key}") String accessKey,
+            @Value("${aws.credentials.secret-key}") String secretKey
+    ) {
+        if (StringUtils.hasText(accessKey) && StringUtils.hasText(secretKey)) {
+            return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+        }
+        return DefaultCredentialsProvider.create();
+    }
+
+    @Bean
+    public S3Client s3Client(
+            @Value("${aws.region}") String region,
+            AwsCredentialsProvider credentialsProvider
+    ) {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(
+            @Value("${aws.region}") String region,
+            AwsCredentialsProvider credentialsProvider
+    ) {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/flover/flover_be/global/exception/CommonErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다. (jpeg, png, webp, heic, heif, avif)");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/flover/flover_be/global/storage/S3StorageService.java
+++ b/src/main/java/com/flover/flover_be/global/storage/S3StorageService.java
@@ -1,0 +1,96 @@
+package com.flover.flover_be.global.storage;
+
+import com.flover.flover_be.global.exception.BusinessException;
+import com.flover.flover_be.global.exception.CommonErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3StorageService {
+
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+            "image/heic",
+            "image/heif",
+            "image/avif"
+    );
+    private static final Duration PRESIGN_DURATION = Duration.ofMinutes(10);
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${aws.region}")
+    private String region;
+
+    public StorageDto.PresignedUploadUrlResponse generatePresignedUploadUrl(String keyPrefix, String contentType) {
+        validateContentType(contentType);
+        String key = "%s/%s%s".formatted(keyPrefix, UUID.randomUUID(), resolveExtension(contentType));
+
+        PresignedPutObjectRequest presigned = s3Presigner.presignPutObject(r -> r
+                .signatureDuration(PRESIGN_DURATION)
+                .putObjectRequest(p -> p
+                        .bucket(bucket)
+                        .key(key)
+                        .contentType(contentType)));
+
+        String objectUrl = "https://%s.s3.%s.amazonaws.com/%s".formatted(bucket, region, key);
+        return new StorageDto.PresignedUploadUrlResponse(presigned.url().toString(), objectUrl);
+    }
+
+    // 우리 버킷 소유 URL이면 삭제. 실패해도 예외 전파 안 함 (업데이트를 막지 않음)
+    public void deleteIfOwnedByBucket(String objectUrl) {
+        if (!isOwnedByBucket(objectUrl)) {
+            return;
+        }
+        try {
+            String key = extractKey(objectUrl);
+            s3Client.deleteObject(r -> r.bucket(bucket).key(key));
+        } catch (S3Exception e) {
+            log.warn("Failed to delete S3 object: {}", objectUrl, e);
+        }
+    }
+
+    private boolean isOwnedByBucket(String objectUrl) {
+        return objectUrl != null && objectUrl.startsWith("https://%s.s3.".formatted(bucket));
+    }
+
+    private String extractKey(String objectUrl) {
+        String prefix = "https://%s.s3.%s.amazonaws.com/".formatted(bucket, region);
+        return objectUrl.substring(prefix.length());
+    }
+
+    private void validateContentType(String contentType) {
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType)) {
+            throw new BusinessException(CommonErrorCode.INVALID_IMAGE_TYPE);
+        }
+    }
+
+    private String resolveExtension(String contentType) {
+        return switch (contentType) {
+            case "image/jpeg" -> ".jpg";
+            case "image/png" -> ".png";
+            case "image/webp" -> ".webp";
+            case "image/heic" -> ".heic";
+            case "image/heif" -> ".heif";
+            case "image/avif" -> ".avif";
+            default -> "";
+        };
+    }
+}

--- a/src/main/java/com/flover/flover_be/global/storage/S3StorageService.java
+++ b/src/main/java/com/flover/flover_be/global/storage/S3StorageService.java
@@ -15,6 +15,8 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.springframework.util.StringUtils.*;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -61,6 +63,9 @@ public class S3StorageService {
         }
         try {
             String key = extractKey(objectUrl);
+            if (!hasText(key)) {
+                return;
+            }
             s3Client.deleteObject(r -> r.bucket(bucket).key(key));
         } catch (S3Exception e) {
             log.warn("Failed to delete S3 object: {}", objectUrl, e);
@@ -72,8 +77,13 @@ public class S3StorageService {
     }
 
     private String extractKey(String objectUrl) {
-        String prefix = "https://%s.s3.%s.amazonaws.com/".formatted(bucket, region);
-        return objectUrl.substring(prefix.length());
+        try {
+            String path = java.net.URI.create(objectUrl).getPath();
+            return (path != null && path.startsWith("/")) ? path.substring(1) : path;
+        } catch (IllegalArgumentException e) {
+            log.warn("Malformed S3 object URL: {}", objectUrl);
+            return "";
+        }
     }
 
     private void validateContentType(String contentType) {

--- a/src/main/java/com/flover/flover_be/global/storage/StorageDto.java
+++ b/src/main/java/com/flover/flover_be/global/storage/StorageDto.java
@@ -1,0 +1,6 @@
+package com.flover.flover_be.global.storage;
+
+public class StorageDto {
+
+    public record PresignedUploadUrlResponse(String uploadUrl, String objectUrl) {}
+}

--- a/src/main/java/com/flover/flover_be/user/controller/UserController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.flover.flover_be.user.controller;
 
 import com.flover.flover_be.global.auth.LoginUserId;
+import com.flover.flover_be.global.storage.StorageDto;
 import com.flover.flover_be.user.dto.UserDto;
 import com.flover.flover_be.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,5 +26,25 @@ public class UserController {
             @RequestBody @Valid UserDto.NicknameRequest request
     ) {
         return ResponseEntity.ok(userService.updateNickname(userId, request.nickname()));
+    }
+
+    @Operation(summary = "프로필 이미지 업로드 URL 발급",
+            description = "S3 Presigned URL을 발급합니다. 프론트엔드는 해당 URL로 직접 PUT 업로드 후 imageUrl을 저장 API로 전달합니다.")
+    @GetMapping("/me/profile-image/upload-url")
+    public ResponseEntity<StorageDto.PresignedUploadUrlResponse> getProfileImageUploadUrl(
+            @LoginUserId Long userId,
+            @RequestParam String contentType
+    ) {
+        return ResponseEntity.ok(userService.generateProfileImagePresignedUrl(userId, contentType));
+    }
+
+    @Operation(summary = "프로필 이미지 URL 저장(수정)",
+            description = "프론트엔드가 S3 업로드 완료 후 imageUrl을 전달하면 DB에 저장합니다. 기존 이미지는 S3에서 삭제시킵니다.")
+    @PutMapping("/me/profile-image")
+    public ResponseEntity<UserDto.ProfileImageResponse> updateProfileImage(
+            @LoginUserId Long userId,
+            @RequestBody @Valid UserDto.ProfileImageUrlRequest request
+    ) {
+        return ResponseEntity.ok(userService.saveProfileImageUrl(userId, request.imageUrl()));
     }
 }

--- a/src/main/java/com/flover/flover_be/user/domain/User.java
+++ b/src/main/java/com/flover/flover_be/user/domain/User.java
@@ -1,5 +1,7 @@
 package com.flover.flover_be.user.domain;
 
+import com.flover.flover_be.user.exception.UserErrorCode;
+import com.flover.flover_be.user.exception.UserException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,6 +16,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
+    private static final long MINUTES_PER_HOUR = 60L;
+    private static final long EXPERIENCE_PER_PLOGGING_HOUR = 100L;
+    private static final long EXPERIENCE_PER_LEVEL = 1_000L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -26,6 +32,15 @@ public class User {
 
     @Column(name = "profile_image_url")
     private String profileImageUrl;
+
+    @Column(nullable = false, columnDefinition = "int default 1")
+    private int level = 1;
+
+    @Column(nullable = false, columnDefinition = "bigint default 0")
+    private long experience = 0L;
+
+    @Column(name = "total_plogging_minutes", nullable = false, columnDefinition = "bigint default 0")
+    private long totalPloggingMinutes = 0L;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
@@ -47,5 +62,19 @@ public class User {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void addPloggingTimeMinutes(long minutes) {
+        if (minutes <= 0) {
+            throw new UserException(UserErrorCode.INVALID_PLOGGING_TIME);
+        }
+
+        this.totalPloggingMinutes += minutes;
+        this.experience = (this.totalPloggingMinutes / MINUTES_PER_HOUR) * EXPERIENCE_PER_PLOGGING_HOUR;
+        this.level = (int) (this.experience / EXPERIENCE_PER_LEVEL) + 1;
     }
 }

--- a/src/main/java/com/flover/flover_be/user/domain/User.java
+++ b/src/main/java/com/flover/flover_be/user/domain/User.java
@@ -16,9 +16,9 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
-    private static final long MINUTES_PER_HOUR = 60L;
-    private static final long EXPERIENCE_PER_PLOGGING_HOUR = 100L;
-    private static final long EXPERIENCE_PER_LEVEL = 1_000L;
+    private static final long EXP_GRANT_INTERVAL_SECONDS = 5L;  // 5초마다 EXP 1 부여
+    private static final long EXP_PER_INTERVAL = 1L;
+    private static final long EXPERIENCE_PER_LEVEL = 720L;       // 1시간 플로깅 시 레벨업
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,8 +39,8 @@ public class User {
     @Column(nullable = false, columnDefinition = "bigint default 0")
     private long experience = 0L;
 
-    @Column(name = "total_plogging_minutes", nullable = false, columnDefinition = "bigint default 0")
-    private long totalPloggingMinutes = 0L;
+    @Column(name = "total_plogging_seconds", nullable = false, columnDefinition = "bigint default 0")
+    private long totalPloggingSeconds = 0L;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
@@ -68,13 +68,13 @@ public class User {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public void addPloggingTimeMinutes(long minutes) {
-        if (minutes <= 0) {
+    public void addPloggingTimeSeconds(long seconds) {
+        if (seconds <= 0) {
             throw new UserException(UserErrorCode.INVALID_PLOGGING_TIME);
         }
 
-        this.totalPloggingMinutes += minutes;
-        this.experience = (this.totalPloggingMinutes / MINUTES_PER_HOUR) * EXPERIENCE_PER_PLOGGING_HOUR;
+        this.totalPloggingSeconds += seconds;
+        this.experience = (this.totalPloggingSeconds / EXP_GRANT_INTERVAL_SECONDS) * EXP_PER_INTERVAL;
         this.level = (int) (this.experience / EXPERIENCE_PER_LEVEL) + 1;
     }
 }

--- a/src/main/java/com/flover/flover_be/user/dto/UserDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/UserDto.java
@@ -7,4 +7,8 @@ public class UserDto {
     public record NicknameRequest(@NotBlank String nickname) {}
 
     public record NicknameResponse(Long userId, String nickname) {}
+
+    public record ProfileImageResponse(Long userId, String profileImageUrl) {}
+
+    public record ProfileImageUrlRequest(@NotBlank String imageUrl) {}
 }

--- a/src/main/java/com/flover/flover_be/user/exception/UserErrorCode.java
+++ b/src/main/java/com/flover/flover_be/user/exception/UserErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    NICKNAME_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+    NICKNAME_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+    INVALID_PLOGGING_TIME(HttpStatus.BAD_REQUEST, "플로깅 시간은 양수여야 합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/flover/flover_be/user/service/ProfileImageStorageService.java
+++ b/src/main/java/com/flover/flover_be/user/service/ProfileImageStorageService.java
@@ -1,0 +1,22 @@
+package com.flover.flover_be.user.service;
+
+import com.flover.flover_be.global.storage.S3StorageService;
+import com.flover.flover_be.global.storage.StorageDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileImageStorageService {
+
+    private final S3StorageService s3StorageService;
+
+    public StorageDto.PresignedUploadUrlResponse generatePresignedUploadUrl(Long userId, String contentType) {
+        return s3StorageService.generatePresignedUploadUrl(
+                "users/%d/profile".formatted(userId), contentType);
+    }
+
+    public void deleteIfOwnedByBucket(String objectUrl) {
+        s3StorageService.deleteIfOwnedByBucket(objectUrl);
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -40,7 +40,9 @@ public class UserService {
     public UserDto.ProfileImageResponse saveProfileImageUrl(Long userId, String imageUrl) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-        profileImageStorageService.deleteIfOwnedByBucket(user.getProfileImageUrl());
+        if (user.getProfileImageUrl() != null && !user.getProfileImageUrl().equals(imageUrl)) {
+            profileImageStorageService.deleteIfOwnedByBucket(user.getProfileImageUrl());
+        }
         user.updateProfileImage(imageUrl);
         return new UserDto.ProfileImageResponse(user.getId(), user.getProfileImageUrl());
     }

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.flover.flover_be.user.service;
 
+import com.flover.flover_be.global.storage.StorageDto;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.dto.UserDto;
 import com.flover.flover_be.user.exception.UserErrorCode;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ProfileImageStorageService profileImageStorageService;
 
     @Transactional
     public UserDto.NicknameResponse updateNickname(Long userId, String nickname) {
@@ -26,5 +28,20 @@ public class UserService {
 
         user.updateNickname(nickname);
         return new UserDto.NicknameResponse(user.getId(), user.getNickname());
+    }
+
+    public StorageDto.PresignedUploadUrlResponse generateProfileImagePresignedUrl(Long userId, String contentType) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        return profileImageStorageService.generatePresignedUploadUrl(userId, contentType);
+    }
+
+    @Transactional
+    public UserDto.ProfileImageResponse saveProfileImageUrl(Long userId, String imageUrl) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        profileImageStorageService.deleteIfOwnedByBucket(user.getProfileImageUrl());
+        user.updateProfileImage(imageUrl);
+        return new UserDto.ProfileImageResponse(user.getId(), user.getProfileImageUrl());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,9 @@ kakao.redirect-uri=${KAKAO_REDIRECT_URI}
 # JWT
 jwt.secret=${JWT_SECRET}
 jwt.expiration=${JWT_EXPIRATION}
+
+# AWS S3
+aws.region=${AWS_REGION:ap-northeast-2}
+aws.s3.bucket=${AWS_S3_BUCKET:plover-be}
+aws.credentials.access-key=${AWS_ACCESS_KEY_ID:}
+aws.credentials.secret-key=${AWS_SECRET_ACCESS_KEY:}

--- a/src/test/java/com/flover/flover_be/global/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/flover/flover_be/global/auth/JwtAuthenticationFilterTest.java
@@ -1,5 +1,6 @@
 package com.flover.flover_be.global.auth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flover.flover_be.global.jwt.JwtProvider;
 import jakarta.servlet.FilterChain;
 import org.junit.jupiter.api.DisplayName;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -20,6 +22,7 @@ import static org.mockito.Mockito.*;
 class JwtAuthenticationFilterTest {
 
     @Mock private JwtProvider jwtProvider;
+    @Spy private ObjectMapper objectMapper = new ObjectMapper();
     @InjectMocks private JwtAuthenticationFilter filter;
 
     @DisplayName("유효한 토큰이면 userId가 request attribute에 저장된다")

--- a/src/test/java/com/flover/flover_be/user/domain/UserTest.java
+++ b/src/test/java/com/flover/flover_be/user/domain/UserTest.java
@@ -21,7 +21,7 @@ class UserTest {
         assertThat(user.getProfileImageUrl()).isEqualTo("http://img.url");
         assertThat(user.getLevel()).isEqualTo(1);
         assertThat(user.getExperience()).isZero();
-        assertThat(user.getTotalPloggingMinutes()).isZero();
+        assertThat(user.getTotalPloggingSeconds()).isZero();
     }
 
     @DisplayName("Update nickname and profile image")
@@ -55,26 +55,48 @@ class UserTest {
         assertThat(user.getProfileImageUrl()).isEqualTo("new.jpg");
     }
 
-    @DisplayName("Add plogging time updates experience and level")
+    @DisplayName("플로깅 시간(초) 추가 시 경험치와 레벨이 갱신된다")
     @Test
-    void addPloggingTimeMinutes_updates_experience_and_level() {
+    void addPloggingTimeSeconds_updates_experience_and_level() {
         User user = User.create(1L, "a@b.com", "nickname", null);
 
-        user.addPloggingTimeMinutes(600L);
+        user.addPloggingTimeSeconds(3600L); // 1시간
 
-        assertThat(user.getTotalPloggingMinutes()).isEqualTo(600L);
-        assertThat(user.getExperience()).isEqualTo(1_000L);
-        assertThat(user.getLevel()).isEqualTo(2);
+        assertThat(user.getTotalPloggingSeconds()).isEqualTo(3600L);
+        assertThat(user.getExperience()).isEqualTo(720L);  // 3600 / 5 * 1
+        assertThat(user.getLevel()).isEqualTo(2);           // 720 / 720 + 1
+    }
+
+    @DisplayName("5초 미만 자투리 시간은 경험치에 반영되지 않는다")
+    @Test
+    void addPloggingTimeSeconds_partial_interval_not_counted() {
+        User user = User.create(1L, "a@b.com", "nickname", null);
+
+        user.addPloggingTimeSeconds(4L); // 5초 미만
+
+        assertThat(user.getExperience()).isZero();
+    }
+
+    @DisplayName("5초 단위로 경험치가 정확히 반영된다")
+    @Test
+    void addPloggingTimeSeconds_grants_exp_every_5_seconds() {
+        User user = User.create(1L, "a@b.com", "nickname", null);
+
+        user.addPloggingTimeSeconds(5L);
+        assertThat(user.getExperience()).isEqualTo(1L);
+
+        user.addPloggingTimeSeconds(5L);
+        assertThat(user.getExperience()).isEqualTo(2L);
     }
 
     @DisplayName("플로깅 시간이 0 이하이면 예외가 발생한다")
     @Test
-    void addPloggingTimeMinutes_invalid_throws_exception() {
+    void addPloggingTimeSeconds_invalid_throws_exception() {
         User user = User.create(1L, "a@b.com", "nickname", null);
 
-        assertThatThrownBy(() -> user.addPloggingTimeMinutes(0L))
+        assertThatThrownBy(() -> user.addPloggingTimeSeconds(0L))
                 .isInstanceOf(UserException.class);
-        assertThatThrownBy(() -> user.addPloggingTimeMinutes(-1L))
+        assertThatThrownBy(() -> user.addPloggingTimeSeconds(-1L))
                 .isInstanceOf(UserException.class);
     }
 }

--- a/src/test/java/com/flover/flover_be/user/domain/UserTest.java
+++ b/src/test/java/com/flover/flover_be/user/domain/UserTest.java
@@ -1,38 +1,80 @@
 package com.flover.flover_be.user.domain;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.flover.flover_be.user.exception.UserException;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UserTest {
 
+    @DisplayName("User.create initializes fields")
     @Test
-    void create_필드_정상_초기화() {
-        User user = User.create(12345L, "test@test.com", "닉네임", "http://img.url");
+    void create_initializes_fields() {
+        User user = User.create(12345L, "test@test.com", "nickname", "http://img.url");
 
         assertThat(user.getKakaoId()).isEqualTo(12345L);
         assertThat(user.getEmail()).isEqualTo("test@test.com");
-        assertThat(user.getNickname()).isEqualTo("닉네임");
+        assertThat(user.getNickname()).isEqualTo("nickname");
         assertThat(user.getProfileImageUrl()).isEqualTo("http://img.url");
+        assertThat(user.getLevel()).isEqualTo(1);
+        assertThat(user.getExperience()).isZero();
+        assertThat(user.getTotalPloggingMinutes()).isZero();
     }
 
+    @DisplayName("Update nickname and profile image")
     @Test
-    void updateProfile_닉네임과_이미지_변경() {
-        User user = User.create(1L, "a@b.com", "기존닉네임", "old.jpg");
+    void updateProfile_updates_nickname_and_profile_image() {
+        User user = User.create(1L, "a@b.com", "oldNickname", "old.jpg");
 
-        user.updateProfile("새닉네임", "new.jpg");
+        user.updateProfile("newNickname", "new.jpg");
 
-        assertThat(user.getNickname()).isEqualTo("새닉네임");
+        assertThat(user.getNickname()).isEqualTo("newNickname");
         assertThat(user.getProfileImageUrl()).isEqualTo("new.jpg");
     }
 
+    @DisplayName("Update nickname")
     @Test
-    void updateNickname_닉네임_변경() {
-        User user = User.create(1L, "a@b.com", "기존닉네임", null);
+    void updateNickname_updates_nickname() {
+        User user = User.create(1L, "a@b.com", "oldNickname", null);
 
-        user.updateNickname("새닉네임");
+        user.updateNickname("newNickname");
 
-        assertThat(user.getNickname()).isEqualTo("새닉네임");
+        assertThat(user.getNickname()).isEqualTo("newNickname");
     }
 
+    @DisplayName("Update profile image")
+    @Test
+    void updateProfileImage_updates_profile_image() {
+        User user = User.create(1L, "a@b.com", "nickname", "old.jpg");
+
+        user.updateProfileImage("new.jpg");
+
+        assertThat(user.getProfileImageUrl()).isEqualTo("new.jpg");
+    }
+
+    @DisplayName("Add plogging time updates experience and level")
+    @Test
+    void addPloggingTimeMinutes_updates_experience_and_level() {
+        User user = User.create(1L, "a@b.com", "nickname", null);
+
+        user.addPloggingTimeMinutes(600L);
+
+        assertThat(user.getTotalPloggingMinutes()).isEqualTo(600L);
+        assertThat(user.getExperience()).isEqualTo(1_000L);
+        assertThat(user.getLevel()).isEqualTo(2);
+    }
+
+    @DisplayName("플로깅 시간이 0 이하이면 예외가 발생한다")
+    @Test
+    void addPloggingTimeMinutes_invalid_throws_exception() {
+        User user = User.create(1L, "a@b.com", "nickname", null);
+
+        assertThatThrownBy(() -> user.addPloggingTimeMinutes(0L))
+                .isInstanceOf(UserException.class);
+        assertThatThrownBy(() -> user.addPloggingTimeMinutes(-1L))
+                .isInstanceOf(UserException.class);
+    }
 }

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.flover.flover_be.user.service;
 
+import com.flover.flover_be.global.storage.StorageDto;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.dto.UserDto;
 import com.flover.flover_be.user.exception.UserException;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.verify;
 class UserServiceTest {
 
     @Mock private UserRepository userRepository;
+    @Mock private ProfileImageStorageService profileImageStorageService;
     @InjectMocks private UserService userService;
 
     @DisplayName("닉네임을 정상적으로 변경한다")
@@ -87,5 +89,87 @@ class UserServiceTest {
 
         // then
         verify(userRepository, never()).existsByNickname(anyString());
+    }
+
+    @DisplayName("Presigned URL 발급 시 유저 존재 확인 후 URL을 반환한다")
+    @Test
+    void generate_profile_image_presigned_url_성공() {
+        // given
+        Long userId = 1L;
+        String contentType = "image/png";
+        String uploadUrl = "https://bucket.s3.amazonaws.com/presigned";
+        String imageUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/uuid.png";
+        User user = User.create(1L, "test@test.com", "nickname", null);
+        StorageDto.PresignedUploadUrlResponse expected = new StorageDto.PresignedUploadUrlResponse(uploadUrl, imageUrl);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(profileImageStorageService.generatePresignedUploadUrl(userId, contentType)).willReturn(expected);
+
+        // when
+        StorageDto.PresignedUploadUrlResponse result = userService.generateProfileImagePresignedUrl(userId, contentType);
+
+        // then
+        assertThat(result.uploadUrl()).isEqualTo(uploadUrl);
+        assertThat(result.objectUrl()).isEqualTo(imageUrl);
+    }
+
+    @DisplayName("Presigned URL 발급 시 유저가 없으면 예외가 발생한다")
+    @Test
+    void generate_profile_image_presigned_url_유저없음_예외() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.generateProfileImagePresignedUrl(1L, "image/png"))
+                .isInstanceOf(UserException.class);
+    }
+
+    @DisplayName("기존 프로필 이미지가 없을 때 새 URL을 저장한다")
+    @Test
+    void save_profile_image_url_기존없음_성공() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/uuid.png";
+        User user = User.create(1L, "test@test.com", "nickname", null);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        UserDto.ProfileImageResponse result = userService.saveProfileImageUrl(userId, newImageUrl);
+
+        // then
+        assertThat(result.profileImageUrl()).isEqualTo(newImageUrl);
+        assertThat(user.getProfileImageUrl()).isEqualTo(newImageUrl);
+        verify(profileImageStorageService).deleteIfOwnedByBucket(null);
+    }
+
+    @DisplayName("기존 프로필 이미지가 있으면 교체 시 삭제를 요청한다")
+    @Test
+    void save_profile_image_url_기존있음_삭제후_저장() {
+        // given
+        Long userId = 1L;
+        String oldImageUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/old.png";
+        String newImageUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/new.png";
+        User user = User.create(1L, "test@test.com", "nickname", oldImageUrl);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        userService.saveProfileImageUrl(userId, newImageUrl);
+
+        // then
+        verify(profileImageStorageService).deleteIfOwnedByBucket(oldImageUrl);
+        assertThat(user.getProfileImageUrl()).isEqualTo(newImageUrl);
+    }
+
+    @DisplayName("프로필 이미지 URL 저장 시 유저가 없으면 예외가 발생한다")
+    @Test
+    void save_profile_image_url_유저없음_예외() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.saveProfileImageUrl(1L, "https://example.com/img.png"))
+                .isInstanceOf(UserException.class);
     }
 }

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -140,7 +141,7 @@ class UserServiceTest {
         // then
         assertThat(result.profileImageUrl()).isEqualTo(newImageUrl);
         assertThat(user.getProfileImageUrl()).isEqualTo(newImageUrl);
-        verify(profileImageStorageService).deleteIfOwnedByBucket(null);
+        verify(profileImageStorageService, never()).deleteIfOwnedByBucket(any());
     }
 
     @DisplayName("기존 프로필 이미지가 있으면 교체 시 삭제를 요청한다")
@@ -160,6 +161,23 @@ class UserServiceTest {
         // then
         verify(profileImageStorageService).deleteIfOwnedByBucket(oldImageUrl);
         assertThat(user.getProfileImageUrl()).isEqualTo(newImageUrl);
+    }
+
+    @DisplayName("동일한 URL로 교체 시 S3 삭제를 요청하지 않는다")
+    @Test
+    void save_profile_image_url_동일_URL_삭제_안함() {
+        // given
+        Long userId = 1L;
+        String sameUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/uuid.png";
+        User user = User.create(1L, "test@test.com", "nickname", sameUrl);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        userService.saveProfileImageUrl(userId, sameUrl);
+
+        // then
+        verify(profileImageStorageService, never()).deleteIfOwnedByBucket(any());
     }
 
     @DisplayName("프로필 이미지 URL 저장 시 유저가 없으면 예외가 발생한다")


### PR DESCRIPTION
## 관련 이슈
- close #7

## 작업 내용

### AWS S3 설정
- AWS SDK v2(`software.amazon.awssdk:s3`) 의존성 추가
- `AwsS3Config` 추가
  - `AwsCredentialsProvider` Bean 등록
  - `S3Client` Bean 등록
  - `S3Presigner` Bean 등록
- `application.properties`에 AWS S3 관련 환경변수 추가
  - `aws.region`
  - `aws.s3.bucket`
  - `aws.credentials.access-key`
  - `aws.credentials.secret-key`
- 로컬 환경에서는 access key/secret key를 사용하고, 값이 없으면 `DefaultCredentialsProvider`를 사용하도록 구성

### 글로벌 S3 스토리지 서비스 구현
- `global/storage/S3StorageService` 구현
  - Presigned PUT URL 발급 로직 분리
  - S3 object URL 생성 로직 분리
  - 기존 S3 오브젝트 삭제 로직 분리
- `global/storage/StorageDto` 추가
  - `PresignedUploadUrlResponse(uploadUrl, objectUrl)` 정의
- `CommonErrorCode`에 `INVALID_IMAGE_TYPE` 추가
  - 이미지 타입 검증 에러를 특정 도메인에 종속되지 않도록 공통 에러로 이동
- 지원 이미지 형식 추가
  - `jpeg`
  - `png`
  - `webp`
  - `heic`
  - `heif`
  - `avif`
- Presigned URL 유효 시간을 10분으로 설정
- Presigned URL 발급 시 `Content-Type`을 고정하여 발급 시점의 이미지 타입과 실제 업로드 타입이 일치하도록 처리

### 프로필 이미지 Presigned URL API 구현
- `ProfileImageStorageService` 구현
  - `users/{userId}/profile` 경로로 S3 key prefix 생성
  - 실제 Presigned URL 발급과 삭제 로직은 `S3StorageService`에 위임
- `UserService`에 프로필 이미지 관련 로직 추가
  - `generateProfileImagePresignedUrl()`
    - 유저 존재 확인 후 Presigned URL 반환
  - `saveProfileImageUrl()`
    - S3 업로드 완료 후 전달받은 이미지 URL을 DB에 저장
    - 기존 프로필 이미지가 우리 S3 버킷에 존재하는 경우 삭제 요청
    - 저장된 최종 `profileImageUrl` 반환
- `UserController`에 API 추가
  - `GET /api/users/me/profile-image/upload-url?contentType=`
    - 프로필 이미지 업로드용 Presigned URL 발급
  - `PUT /api/users/me/profile-image`
    - 요청 body: `{ "imageUrl": "..." }`
    - 업로드 완료된 이미지 URL을 사용자 프로필 이미지로 저장
- `UserDto` 수정
  - `ProfileImageUrlRequest` 추가
  - `ProfileImageResponse` 추가
  - 기존 Presigned URL 응답 DTO는 공통 `StorageDto`로 분리

### User 엔티티 수정
- 사용자 레벨 관련 필드 추가
  - `level`
  - `experience`
  - `totalPloggingMinutes`
- `User.updateProfileImage()` 도메인 메서드 추가
  - public setter 없이 프로필 이미지 URL을 변경하도록 처리
- `User.addPloggingTimeMinutes()` 메서드 추가
  - 누적 플로깅 시간을 기반으로 경험치와 레벨 계산
  - 플로깅 시간이 0 이하인 경우 `UserException(INVALID_PLOGGING_TIME)` 발생
- `UserErrorCode`에 `INVALID_PLOGGING_TIME` 추가

### AI 개발 문서 보완
- `.ai/code_convention.md`에 S3 Presigned URL 업로드 패턴 추가
- `.ai/skills.md`에 AWS SDK v2 사용 내용 추가
- `.ai/test_convention.md`에 `@Mock`과 `@Spy` 사용 기준 추가

### 테스트
- `UserTest`
  - User 생성 시 레벨, 경험치, 누적 플로깅 시간 기본값 검증 추가
  - 프로필 이미지 변경 메서드 테스트 추가
  - 플로깅 시간 추가 시 경험치/레벨 계산 테스트 추가
  - 플로깅 시간이 0 이하일 때 예외가 발생하는 케이스 추가
- `UserServiceTest`
  - 프로필 이미지 Presigned URL 발급 테스트 추가
  - Presigned URL 발급 시 유저가 없을 때 예외 케이스 추가
  - 프로필 이미지 URL 저장 테스트 추가
  - 기존 이미지가 있는 경우 삭제 요청 후 새 URL 저장 테스트 추가
  - 기존 이미지가 없는 경우 새 URL 저장 테스트 추가
- `JwtAuthenticationFilterTest`
  - `ObjectMapper`를 `@Spy`로 주입하여 필터 에러 응답 테스트에서 실제 JSON 직렬화가 동작하도록 수정

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.