### PR TITLE
[feat]: 유저 정보 조회 API 구현 (닉네임,레벨,프로필 사진)

### DIFF
--- a/src/main/java/com/flover/flover_be/user/controller/UserController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/UserController.java
@@ -21,7 +21,7 @@ public class UserController {
 
     @Operation(summary = "유저 정보 조회", description = "닉네임, 레벨, 프로필 이미지 URL 반환")
     @GetMapping("/{userId}")
-    public ResponseEntity<UserDto.UserInfoResponse> getUserInfo(@PathVariable Long userId) {
+    public ResponseEntity<UserDto.UserInfoResponse> getUserInfo(@PathVariable @Positive Long userId) {
         return ResponseEntity.ok(userService.findUserInfo(userId));
     }
 

--- a/src/main/java/com/flover/flover_be/user/controller/UserController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/UserController.java
@@ -19,6 +19,12 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "유저 정보 조회", description = "닉네임, 레벨, 프로필 이미지 URL 반환")
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserDto.UserInfoResponse> getUserInfo(@PathVariable Long userId) {
+        return ResponseEntity.ok(userService.findUserInfo(userId));
+    }
+
     @Operation(summary = "닉네임 수정", description = "사용자 닉네임 변경")
     @PutMapping("/me/nickname")
     public ResponseEntity<UserDto.NicknameResponse> updateNickname(

--- a/src/main/java/com/flover/flover_be/user/dto/UserDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/UserDto.java
@@ -11,4 +11,6 @@ public class UserDto {
     public record ProfileImageResponse(Long userId, String profileImageUrl) {}
 
     public record ProfileImageUrlRequest(@NotBlank String imageUrl) {}
+
+    public record UserInfoResponse(String nickname, int level, String profileImageUrl) {}
 }

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -17,6 +17,13 @@ public class UserService {
     private final UserRepository userRepository;
     private final ProfileImageStorageService profileImageStorageService;
 
+    @Transactional(readOnly = true)
+    public UserDto.UserInfoResponse findUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        return new UserDto.UserInfoResponse(user.getNickname(), user.getLevel(), user.getProfileImageUrl());
+    }
+
     @Transactional
     public UserDto.NicknameResponse updateNickname(Long userId, String nickname) {
         User user = userRepository.findById(userId)

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.flover.flover_be.user.service;
 import com.flover.flover_be.global.storage.StorageDto;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.dto.UserDto;
+import com.flover.flover_be.user.exception.UserErrorCode;
 import com.flover.flover_be.user.exception.UserException;
 import com.flover.flover_be.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -84,8 +85,9 @@ class UserServiceTest {
         given(userRepository.findById(anyLong())).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.updateNickname(1L, "새닉네임"))
-                .isInstanceOf(UserException.class);
+        assertThatThrownBy(() -> userService.findUserInfo(1L))
+                .isInstanceOf(UserException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
     }
 
     @DisplayName("이미 사용 중인 닉네임으로 변경 시 예외가 발생한다")

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -30,6 +30,35 @@ class UserServiceTest {
     @Mock private ProfileImageStorageService profileImageStorageService;
     @InjectMocks private UserService userService;
 
+    @DisplayName("유저 정보를 정상적으로 조회한다")
+    @Test
+    void find_user_info_성공() {
+        // given
+        Long userId = 1L;
+        User user = User.create(1L, "test@test.com", "닉네임", "https://img.url/profile.png");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        UserDto.UserInfoResponse result = userService.findUserInfo(userId);
+
+        // then
+        assertThat(result.nickname()).isEqualTo("닉네임");
+        assertThat(result.level()).isEqualTo(1);
+        assertThat(result.profileImageUrl()).isEqualTo("https://img.url/profile.png");
+    }
+
+    @DisplayName("존재하지 않는 유저 정보 조회 시 예외가 발생한다")
+    @Test
+    void find_user_info_유저없음_예외() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.findUserInfo(1L))
+                .isInstanceOf(UserException.class);
+    }
+
     @DisplayName("닉네임을 정상적으로 변경한다")
     @Test
     void update_nickname_성공() {


### PR DESCRIPTION
## 관련 이슈
- close #9 

## 작업 내용
- `GET /api/users/{userId}` 엔드포인트 추가
  - `userId`를 Path Variable로 받아 특정 사용자 정보 조회
  - 인증 없이 공개 조회 가능
- 사용자 기본 정보 응답 DTO 추가
  - 닉네임
  - 레벨
  - 프로필 이미지 URL
- 존재하지 않는 사용자 조회 시 예외 처리
  - `USER_NOT_FOUND`

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.

## 참고
- 이슈에도 적어놓았듯이 칭호 관련 정보는 추후 기능 확장 시 추가할 예정입니다.
<img width="734" height="205" alt="image" src="https://github.com/user-attachments/assets/925d58c4-6b5f-4e73-9f10-8349d999ca05" />
