### PR TITLE
[feat]: 유저 칭호 필드 및 로직 추가

### DIFF
--- a/src/main/java/com/flover/flover_be/user/controller/UserController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.flover.flover_be.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/flover/flover_be/user/domain/User.java
+++ b/src/main/java/com/flover/flover_be/user/domain/User.java
@@ -42,8 +42,9 @@ public class User {
     @Column(name = "total_plogging_seconds", nullable = false, columnDefinition = "bigint default 0")
     private long totalPloggingSeconds = 0L;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "title", nullable = false)
-    private String title = UserTitle.쓰봉이.getDisplayName();
+    private UserTitle title = UserTitle.쓰봉이;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/src/main/java/com/flover/flover_be/user/domain/User.java
+++ b/src/main/java/com/flover/flover_be/user/domain/User.java
@@ -42,6 +42,9 @@ public class User {
     @Column(name = "total_plogging_seconds", nullable = false, columnDefinition = "bigint default 0")
     private long totalPloggingSeconds = 0L;
 
+    @Column(name = "title", nullable = false)
+    private String title = UserTitle.쓰봉이.getDisplayName();
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -76,5 +79,6 @@ public class User {
         this.totalPloggingSeconds += seconds;
         this.experience = (this.totalPloggingSeconds / EXP_GRANT_INTERVAL_SECONDS) * EXP_PER_INTERVAL;
         this.level = (int) (this.experience / EXPERIENCE_PER_LEVEL) + 1;
+        this.title = UserTitle.of(this.level);
     }
 }

--- a/src/main/java/com/flover/flover_be/user/domain/UserTitle.java
+++ b/src/main/java/com/flover/flover_be/user/domain/UserTitle.java
@@ -1,0 +1,42 @@
+package com.flover.flover_be.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserTitle {
+
+    쓰봉이(1, "쓰봉이"),
+    새싹_수거자(2, "새싹 수거자"),
+    쓰줍_초보자(5, "쓰줍 초보자"),
+    쓰줍_중급자(10, "쓰줍 중급자"),
+    쓰줍_고수(15, "쓰줍 고수"),
+    거리의_청소부(20, "거리의 청소부"),
+    거리_구조대(30, "거리 구조대"),
+    도시_정화자(40, "도시 정화자"),
+    플로깅_모험가(50, "플로깅 모험가"),
+    플로깅_탐험가(60, "플로깅 탐험가"),
+    플로깅_대장(70, "플로깅 대장"),
+    플로깅_레전드(80, "플로깅 레전드"),
+    환경_수호자(90, "환경 수호자"),
+    환경의_신(100, "환경의 신"),
+    ONE_TRASH_ONE_FOLLOW(150, "1trash1follow"),
+    환경부장관(200, "환경부장관");
+
+    private final int minLevel;
+    private final String displayName;
+
+    // 현재 레벨 이하에서 가장 높은 칭호 반환
+    public static String of(int level) {
+        String result = 쓰봉이.displayName;
+        for (UserTitle title : values()) {
+            if (level >= title.minLevel) {
+                result = title.displayName;
+            } else {
+                break;
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/domain/UserTitle.java
+++ b/src/main/java/com/flover/flover_be/user/domain/UserTitle.java
@@ -3,6 +3,10 @@ package com.flover.flover_be.user.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
 @Getter
 @RequiredArgsConstructor
 public enum UserTitle {
@@ -27,16 +31,20 @@ public enum UserTitle {
     private final int minLevel;
     private final String displayName;
 
-    // 현재 레벨 이하에서 가장 높은 칭호 반환
-    public static String of(int level) {
-        String result = 쓰봉이.displayName;
+    private static final NavigableMap<Integer, UserTitle> LEVEL_MAP = new TreeMap<>();
+
+    static {
         for (UserTitle title : values()) {
-            if (level >= title.minLevel) {
-                result = title.displayName;
-            } else {
-                break;
-            }
+            LEVEL_MAP.put(title.minLevel, title);
         }
-        return result;
+    }
+
+    // 현재 레벨 이하에서 가장 높은 칭호 반환
+    public static UserTitle of(int level) {
+        Map.Entry<Integer, UserTitle> entry = LEVEL_MAP.floorEntry(level);
+        if (entry == null) {
+            return 쓰봉이;
+        }
+        return entry.getValue();
     }
 }

--- a/src/main/java/com/flover/flover_be/user/dto/UserDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/UserDto.java
@@ -12,5 +12,5 @@ public class UserDto {
 
     public record ProfileImageUrlRequest(@NotBlank String imageUrl) {}
 
-    public record UserInfoResponse(String nickname, int level, String profileImageUrl) {}
+    public record UserInfoResponse(String nickname, int level, String title, String profileImageUrl) {}
 }

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
     public UserDto.UserInfoResponse findUserInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-        return new UserDto.UserInfoResponse(user.getNickname(), user.getLevel(), user.getTitle(), user.getProfileImageUrl());
+        return new UserDto.UserInfoResponse(user.getNickname(), user.getLevel(), user.getTitle().getDisplayName(), user.getProfileImageUrl());
     }
 
     @Transactional

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
     public UserDto.UserInfoResponse findUserInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-        return new UserDto.UserInfoResponse(user.getNickname(), user.getLevel(), user.getProfileImageUrl());
+        return new UserDto.UserInfoResponse(user.getNickname(), user.getLevel(), user.getTitle(), user.getProfileImageUrl());
     }
 
     @Transactional

--- a/src/test/java/com/flover/flover_be/user/domain/UserTest.java
+++ b/src/test/java/com/flover/flover_be/user/domain/UserTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.flover.flover_be.user.exception.UserException;
+import com.flover.flover_be.user.domain.UserTitle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,7 +23,7 @@ class UserTest {
         assertThat(user.getLevel()).isEqualTo(1);
         assertThat(user.getExperience()).isZero();
         assertThat(user.getTotalPloggingSeconds()).isZero();
-        assertThat(user.getTitle()).isEqualTo("쓰봉이");
+        assertThat(user.getTitle()).isEqualTo(UserTitle.쓰봉이);
     }
 
     @DisplayName("Update nickname and profile image")
@@ -66,7 +67,7 @@ class UserTest {
         assertThat(user.getTotalPloggingSeconds()).isEqualTo(3600L);
         assertThat(user.getExperience()).isEqualTo(720L);  // 3600 / 5 * 1
         assertThat(user.getLevel()).isEqualTo(2);           // 720 / 720 + 1
-        assertThat(user.getTitle()).isEqualTo("새싹 수거자"); // level 2
+        assertThat(user.getTitle()).isEqualTo(UserTitle.새싹_수거자); // level 2
     }
 
     @DisplayName("5초 미만 자투리 시간은 경험치에 반영되지 않는다")
@@ -100,7 +101,7 @@ class UserTest {
         user.addPloggingTimeSeconds(3600L * 17); // 17시간 → level 18
         // 17시간 = 3600 * 17 = 61200초 → EXP = 61200/5 = 12240 → level = 12240/720+1 = 18
         // level 18 → 쓰줍 고수 (15 이상 20 미만)
-        assertThat(user.getTitle()).isEqualTo("쓰줍 고수");
+        assertThat(user.getTitle()).isEqualTo(UserTitle.쓰줍_고수);
     }
 
     @DisplayName("레벨 기준과 정확히 일치하면 해당 칭호가 적용된다")
@@ -112,7 +113,7 @@ class UserTest {
         // level 5 = EXP 2880 = totalSeconds 14400 (4시간)
         user.addPloggingTimeSeconds(3600L * 4); // 4시간 → level 5
         assertThat(user.getLevel()).isEqualTo(5);
-        assertThat(user.getTitle()).isEqualTo("쓰줍 초보자");
+        assertThat(user.getTitle()).isEqualTo(UserTitle.쓰줍_초보자);
     }
 
     @DisplayName("플로깅 시간이 0 이하이면 예외가 발생한다")

--- a/src/test/java/com/flover/flover_be/user/domain/UserTest.java
+++ b/src/test/java/com/flover/flover_be/user/domain/UserTest.java
@@ -22,6 +22,7 @@ class UserTest {
         assertThat(user.getLevel()).isEqualTo(1);
         assertThat(user.getExperience()).isZero();
         assertThat(user.getTotalPloggingSeconds()).isZero();
+        assertThat(user.getTitle()).isEqualTo("쓰봉이");
     }
 
     @DisplayName("Update nickname and profile image")
@@ -55,7 +56,7 @@ class UserTest {
         assertThat(user.getProfileImageUrl()).isEqualTo("new.jpg");
     }
 
-    @DisplayName("플로깅 시간(초) 추가 시 경험치와 레벨이 갱신된다")
+    @DisplayName("플로깅 시간(초) 추가 시 경험치, 레벨, 칭호가 갱신된다")
     @Test
     void addPloggingTimeSeconds_updates_experience_and_level() {
         User user = User.create(1L, "a@b.com", "nickname", null);
@@ -65,6 +66,7 @@ class UserTest {
         assertThat(user.getTotalPloggingSeconds()).isEqualTo(3600L);
         assertThat(user.getExperience()).isEqualTo(720L);  // 3600 / 5 * 1
         assertThat(user.getLevel()).isEqualTo(2);           // 720 / 720 + 1
+        assertThat(user.getTitle()).isEqualTo("새싹 수거자"); // level 2
     }
 
     @DisplayName("5초 미만 자투리 시간은 경험치에 반영되지 않는다")
@@ -87,6 +89,30 @@ class UserTest {
 
         user.addPloggingTimeSeconds(5L);
         assertThat(user.getExperience()).isEqualTo(2L);
+    }
+
+    @DisplayName("레벨 기준 사이 구간에서도 현재 레벨 이하 최고 칭호가 적용된다")
+    @Test
+    void title_reflects_highest_applicable_for_level_in_between() {
+        User user = User.create(1L, "a@b.com", "nickname", null);
+
+        // level 17 → 쓰줍 고수 (15레벨 기준, 20레벨 미달)
+        user.addPloggingTimeSeconds(3600L * 17); // 17시간 → level 18
+        // 17시간 = 3600 * 17 = 61200초 → EXP = 61200/5 = 12240 → level = 12240/720+1 = 18
+        // level 18 → 쓰줍 고수 (15 이상 20 미만)
+        assertThat(user.getTitle()).isEqualTo("쓰줍 고수");
+    }
+
+    @DisplayName("레벨 기준과 정확히 일치하면 해당 칭호가 적용된다")
+    @Test
+    void title_changes_exactly_at_level_threshold() {
+        User user = User.create(1L, "a@b.com", "nickname", null);
+
+        // level 5 정확히 달성 → 쓰줍 초보자
+        // level 5 = EXP 2880 = totalSeconds 14400 (4시간)
+        user.addPloggingTimeSeconds(3600L * 4); // 4시간 → level 5
+        assertThat(user.getLevel()).isEqualTo(5);
+        assertThat(user.getTitle()).isEqualTo("쓰줍 초보자");
     }
 
     @DisplayName("플로깅 시간이 0 이하이면 예외가 발생한다")

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -46,6 +46,7 @@ class UserServiceTest {
         // then
         assertThat(result.nickname()).isEqualTo("닉네임");
         assertThat(result.level()).isEqualTo(1);
+        assertThat(result.title()).isEqualTo("쓰봉이");
         assertThat(result.profileImageUrl()).isEqualTo("https://img.url/profile.png");
     }
 


### PR DESCRIPTION
## 관련 이슈
- close #11

## 작업 내용
- `UserTitle` enum 추가
  - 레벨별 칭호 정책 정의
  - 기본 칭호 `쓰봉이`부터 `환경부장관`까지 총 16단계 구성
  - 현재 레벨 이하에서 가장 높은 기준의 칭호가 적용되도록 구현
- `User` 엔티티에 `title` 필드 추가
  - 기본 칭호는 `쓰봉이`로 설정
- `addPloggingTimeSeconds()` 호출 시 레벨 갱신과 함께 칭호가 자동 갱신되도록 수정
- 유저 정보 조회 응답(`UserInfoResponse`)에 `title` 필드 추가

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.

## 참고
<img width="367" height="503" alt="image" src="https://github.com/user-attachments/assets/a795f181-a259-4d04-b712-6048a2f6916e" />
