### PR TITLE
[feat]: 플로깅 완료 기록 저장 API 구현

### DIFF
--- a/src/main/java/com/flover/flover_be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flover/flover_be/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
 package com.flover.flover_be.global.exception;
 
 import com.flover.flover_be.global.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -18,6 +20,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("[500 INTERNAL_SERVER_ERROR] {} : {}", e.getClass().getSimpleName(), e.getMessage(), e);
         ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity
                 .status(errorCode.getStatus())

--- a/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
+++ b/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
@@ -1,0 +1,33 @@
+package com.flover.flover_be.plogging.controller;
+
+import com.flover.flover_be.global.auth.LoginUserId;
+import com.flover.flover_be.plogging.dto.PloggingDto;
+import com.flover.flover_be.plogging.service.PloggingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Plogging", description = "플로깅 API")
+@RestController
+@RequestMapping("/api/plogging-sessions")
+@RequiredArgsConstructor
+public class PloggingController {
+
+    private final PloggingService ploggingService;
+
+    @Operation(summary = "플로깅 완료 기록 저장",
+            description = "플로깅 완료 데이터를 저장합니다. 지도 이미지와 인증샷은 S3 URL로 전달합니다.")
+    @PostMapping("/complete")
+    public ResponseEntity<PloggingDto.CompleteResponse> completePlogging(
+            @LoginUserId Long userId,
+            @RequestBody @Valid PloggingDto.CompleteRequest request
+    ) {
+        return ResponseEntity.ok(ploggingService.complete(userId, request));
+    }
+}

--- a/src/main/java/com/flover/flover_be/plogging/domain/PloggingMode.java
+++ b/src/main/java/com/flover/flover_be/plogging/domain/PloggingMode.java
@@ -1,0 +1,6 @@
+package com.flover.flover_be.plogging.domain;
+
+public enum PloggingMode {
+    FREE, //자유 플로깅
+    RECOMMENDED //추천 경로 플로깅
+}

--- a/src/main/java/com/flover/flover_be/plogging/domain/PloggingPhoto.java
+++ b/src/main/java/com/flover/flover_be/plogging/domain/PloggingPhoto.java
@@ -1,0 +1,39 @@
+package com.flover.flover_be.plogging.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "plogging_photos")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PloggingPhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plogging_session_id", nullable = false)
+    private PloggingSession ploggingSession;
+
+    @Column(nullable = false)
+    private int sequence;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    public static PloggingPhoto create(
+            PloggingSession ploggingSession,
+            int sequence,
+            String imageUrl
+    ) {
+        PloggingPhoto photo = new PloggingPhoto();
+        photo.ploggingSession = ploggingSession;
+        photo.sequence = sequence;
+        photo.imageUrl = imageUrl;
+        return photo;
+    }
+}

--- a/src/main/java/com/flover/flover_be/plogging/domain/PloggingRoutePoint.java
+++ b/src/main/java/com/flover/flover_be/plogging/domain/PloggingRoutePoint.java
@@ -1,0 +1,44 @@
+package com.flover.flover_be.plogging.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "plogging_route_points")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PloggingRoutePoint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plogging_session_id", nullable = false)
+    private PloggingSession ploggingSession;
+
+    @Column(nullable = false)
+    private int sequence;
+
+    @Column(nullable = false)
+    private double latitude;
+
+    @Column(nullable = false)
+    private double longitude;
+
+    public static PloggingRoutePoint create(
+            PloggingSession ploggingSession,
+            int sequence,
+            double latitude,
+            double longitude
+    ) {
+        PloggingRoutePoint point = new PloggingRoutePoint();
+        point.ploggingSession = ploggingSession;
+        point.sequence = sequence;
+        point.latitude = latitude;
+        point.longitude = longitude;
+        return point;
+    }
+}

--- a/src/main/java/com/flover/flover_be/plogging/domain/PloggingSession.java
+++ b/src/main/java/com/flover/flover_be/plogging/domain/PloggingSession.java
@@ -1,0 +1,101 @@
+package com.flover.flover_be.plogging.domain;
+
+import com.flover.flover_be.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "plogging_sessions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PloggingSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PloggingMode mode;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "finished_at", nullable = false)
+    private LocalDateTime finishedAt;
+
+    @Column(name = "distance_meters", nullable = false)
+    private int distanceMeters;
+
+    @Column(name = "step_count", nullable = false)
+    private int stepCount;
+
+    @Column(name = "calories_burned", nullable = false)
+    private int caloriesBurned;
+
+    @Column(name = "plogging_seconds", nullable = false)
+    private int ploggingSeconds;
+
+    @Column(name = "rest_seconds", nullable = false)
+    private int restSeconds;
+
+    @Column(name = "place_name")
+    private String placeName;
+
+    @Column(name = "start_latitude", nullable = false)
+    private double startLatitude;
+
+    @Column(name = "start_longitude", nullable = false)
+    private double startLongitude;
+
+    @Column(name = "end_latitude", nullable = false)
+    private double endLatitude;
+
+    @Column(name = "end_longitude", nullable = false)
+    private double endLongitude;
+
+    @Column(name = "map_image_url")
+    private String mapImageUrl;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    public static PloggingSession create(
+            User user, PloggingMode mode,
+            LocalDateTime startedAt, LocalDateTime finishedAt,
+            int distanceMeters, int stepCount, int caloriesBurned,
+            int ploggingSeconds, int restSeconds,
+            String placeName,
+            double startLatitude, double startLongitude,
+            double endLatitude, double endLongitude,
+            String mapImageUrl
+    ) {
+        PloggingSession session = new PloggingSession();
+        session.user = user;
+        session.mode = mode;
+        session.startedAt = startedAt;
+        session.finishedAt = finishedAt;
+        session.distanceMeters = distanceMeters;
+        session.stepCount = stepCount;
+        session.caloriesBurned = caloriesBurned;
+        session.ploggingSeconds = ploggingSeconds;
+        session.restSeconds = restSeconds;
+        session.placeName = placeName;
+        session.startLatitude = startLatitude;
+        session.startLongitude = startLongitude;
+        session.endLatitude = endLatitude;
+        session.endLongitude = endLongitude;
+        session.mapImageUrl = mapImageUrl;
+        return session;
+    }
+}

--- a/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
+++ b/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
@@ -4,6 +4,7 @@ import com.flover.flover_be.plogging.domain.PloggingMode;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -29,7 +30,7 @@ public class PloggingDto {
             @NotNull @DecimalMin("-180.0") @DecimalMax("180.0") Double endLongitude,
             @NotNull @Valid List<RoutePointRequest> routePoints,
             String mapImageUrl,
-            @NotNull List<String> photoUrls
+            @NotNull List<@NotBlank String> photoUrls
     ) {}
 
     public record RoutePointRequest(

--- a/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
+++ b/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
@@ -1,0 +1,39 @@
+package com.flover.flover_be.plogging.dto;
+
+import com.flover.flover_be.plogging.domain.PloggingMode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PloggingDto {
+
+    public record CompleteRequest(
+            @NotNull PloggingMode mode,
+            @NotNull LocalDateTime startedAt,
+            @NotNull LocalDateTime finishedAt,
+            @PositiveOrZero int distanceMeters,
+            @PositiveOrZero int stepCount,
+            @PositiveOrZero int caloriesBurned,
+            @Positive int ploggingSeconds,
+            @PositiveOrZero int restSeconds,
+            String placeName,
+            @NotNull Double startLatitude,
+            @NotNull Double startLongitude,
+            @NotNull Double endLatitude,
+            @NotNull Double endLongitude,
+            @NotNull @Valid List<RoutePointRequest> routePoints,
+            String mapImageUrl,
+            @NotNull List<String> photoUrls
+    ) {}
+
+    public record RoutePointRequest(
+            @NotNull Double latitude,
+            @NotNull Double longitude
+    ) {}
+
+    public record CompleteResponse(Long ploggingSessionId) {}
+}

--- a/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
+++ b/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
@@ -2,6 +2,8 @@ package com.flover.flover_be.plogging.dto;
 
 import com.flover.flover_be.plogging.domain.PloggingMode;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -21,18 +23,18 @@ public class PloggingDto {
             @Positive int ploggingSeconds,
             @PositiveOrZero int restSeconds,
             String placeName,
-            @NotNull Double startLatitude,
-            @NotNull Double startLongitude,
-            @NotNull Double endLatitude,
-            @NotNull Double endLongitude,
+            @NotNull @DecimalMin("-90.0") @DecimalMax("90.0") Double startLatitude,
+            @NotNull @DecimalMin("-180.0") @DecimalMax("180.0") Double startLongitude,
+            @NotNull @DecimalMin("-90.0") @DecimalMax("90.0") Double endLatitude,
+            @NotNull @DecimalMin("-180.0") @DecimalMax("180.0") Double endLongitude,
             @NotNull @Valid List<RoutePointRequest> routePoints,
             String mapImageUrl,
             @NotNull List<String> photoUrls
     ) {}
 
     public record RoutePointRequest(
-            @NotNull Double latitude,
-            @NotNull Double longitude
+            @NotNull @DecimalMin("-90.0") @DecimalMax("90.0") Double latitude,
+            @NotNull @DecimalMin("-180.0") @DecimalMax("180.0") Double longitude
     ) {}
 
     public record CompleteResponse(Long ploggingSessionId) {}

--- a/src/main/java/com/flover/flover_be/plogging/exception/PloggingErrorCode.java
+++ b/src/main/java/com/flover/flover_be/plogging/exception/PloggingErrorCode.java
@@ -1,0 +1,16 @@
+package com.flover.flover_be.plogging.exception;
+
+import com.flover.flover_be.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PloggingErrorCode implements ErrorCode {
+
+    PLOGGING_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "플로깅 세션을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/flover/flover_be/plogging/exception/PloggingException.java
+++ b/src/main/java/com/flover/flover_be/plogging/exception/PloggingException.java
@@ -1,0 +1,11 @@
+package com.flover.flover_be.plogging.exception;
+
+import com.flover.flover_be.global.exception.BusinessException;
+import com.flover.flover_be.global.exception.ErrorCode;
+
+public class PloggingException extends BusinessException {
+
+    public PloggingException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingPhotoRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingPhotoRepository.java
@@ -1,0 +1,7 @@
+package com.flover.flover_be.plogging.repository;
+
+import com.flover.flover_be.plogging.domain.PloggingPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PloggingPhotoRepository extends JpaRepository<PloggingPhoto, Long> {
+}

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingRoutePointRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingRoutePointRepository.java
@@ -1,0 +1,7 @@
+package com.flover.flover_be.plogging.repository;
+
+import com.flover.flover_be.plogging.domain.PloggingRoutePoint;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PloggingRoutePointRepository extends JpaRepository<PloggingRoutePoint, Long> {
+}

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
@@ -1,0 +1,7 @@
+package com.flover.flover_be.plogging.repository;
+
+import com.flover.flover_be.plogging.domain.PloggingSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PloggingSessionRepository extends JpaRepository<PloggingSession, Long> {
+}

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -1,0 +1,71 @@
+package com.flover.flover_be.plogging.service;
+
+import com.flover.flover_be.plogging.domain.PloggingPhoto;
+import com.flover.flover_be.plogging.domain.PloggingRoutePoint;
+import com.flover.flover_be.plogging.domain.PloggingSession;
+import com.flover.flover_be.plogging.dto.PloggingDto;
+import com.flover.flover_be.plogging.repository.PloggingPhotoRepository;
+import com.flover.flover_be.plogging.repository.PloggingRoutePointRepository;
+import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
+import com.flover.flover_be.user.domain.User;
+import com.flover.flover_be.user.exception.UserErrorCode;
+import com.flover.flover_be.user.exception.UserException;
+import com.flover.flover_be.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PloggingService {
+
+    private final UserRepository userRepository;
+    private final PloggingSessionRepository ploggingSessionRepository;
+    private final PloggingRoutePointRepository ploggingRoutePointRepository;
+    private final PloggingPhotoRepository ploggingPhotoRepository;
+
+    @Transactional
+    public PloggingDto.CompleteResponse complete(Long userId, PloggingDto.CompleteRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        PloggingSession session = PloggingSession.create(
+                user, request.mode(),
+                request.startedAt(), request.finishedAt(),
+                request.distanceMeters(), request.stepCount(), request.caloriesBurned(),
+                request.ploggingSeconds(), request.restSeconds(),
+                request.placeName(),
+                request.startLatitude(), request.startLongitude(),
+                request.endLatitude(), request.endLongitude(),
+                request.mapImageUrl()
+        );
+        PloggingSession savedSession = ploggingSessionRepository.save(session);
+
+        saveRoutePoints(savedSession, request.routePoints());
+        savePhotos(savedSession, request.photoUrls());
+
+        user.addPloggingTimeSeconds(request.ploggingSeconds());
+
+        return new PloggingDto.CompleteResponse(savedSession.getId());
+    }
+
+    private void saveRoutePoints(PloggingSession session, List<PloggingDto.RoutePointRequest> routePoints) {
+        List<PloggingRoutePoint> points = new ArrayList<>();
+        for (int i = 0; i < routePoints.size(); i++) {
+            PloggingDto.RoutePointRequest rp = routePoints.get(i);
+            points.add(PloggingRoutePoint.create(session, i, rp.latitude(), rp.longitude()));
+        }
+        ploggingRoutePointRepository.saveAll(points);
+    }
+
+    private void savePhotos(PloggingSession session, List<String> photoUrls) {
+        List<PloggingPhoto> photos = new ArrayList<>();
+        for (int i = 0; i < photoUrls.size(); i++) {
+            photos.add(PloggingPhoto.create(session, i, photoUrls.get(i)));
+        }
+        ploggingPhotoRepository.saveAll(photos);
+    }
+}

--- a/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
@@ -1,0 +1,207 @@
+package com.flover.flover_be.plogging.service;
+
+import com.flover.flover_be.plogging.domain.PloggingMode;
+import com.flover.flover_be.plogging.domain.PloggingPhoto;
+import com.flover.flover_be.plogging.domain.PloggingRoutePoint;
+import com.flover.flover_be.plogging.domain.PloggingSession;
+import com.flover.flover_be.plogging.dto.PloggingDto;
+import com.flover.flover_be.plogging.repository.PloggingPhotoRepository;
+import com.flover.flover_be.plogging.repository.PloggingRoutePointRepository;
+import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
+import com.flover.flover_be.user.domain.User;
+import com.flover.flover_be.user.exception.UserException;
+import com.flover.flover_be.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PloggingServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private PloggingSessionRepository ploggingSessionRepository;
+    @Mock private PloggingRoutePointRepository ploggingRoutePointRepository;
+    @Mock private PloggingPhotoRepository ploggingPhotoRepository;
+    @InjectMocks private PloggingService ploggingService;
+
+    @DisplayName("플로깅 완료 기록을 정상적으로 저장한다")
+    @Test
+    void complete_성공() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        PloggingDto.CompleteRequest request = buildRequest(List.of(
+                new PloggingDto.RoutePointRequest(37.1, 127.1),
+                new PloggingDto.RoutePointRequest(37.2, 127.2)
+        ), List.of("https://s3.example.com/photo1.jpg"));
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.save(any(PloggingSession.class))).willAnswer(i -> i.getArgument(0));
+        given(ploggingRoutePointRepository.saveAll(any())).willReturn(List.of());
+        given(ploggingPhotoRepository.saveAll(any())).willReturn(List.of());
+
+        // when
+        PloggingDto.CompleteResponse result = ploggingService.complete(userId, request);
+
+        // then
+        assertThat(result.ploggingSessionId()).isNull(); // ID는 DB 채번이므로 null
+        verify(ploggingSessionRepository).save(any(PloggingSession.class));
+    }
+
+    @DisplayName("존재하지 않는 유저로 플로깅 완료 저장 시 예외가 발생한다")
+    @Test
+    void complete_유저없음_예외() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+        PloggingDto.CompleteRequest request = buildRequest(List.of(), List.of());
+
+        // when & then
+        assertThatThrownBy(() -> ploggingService.complete(1L, request))
+                .isInstanceOf(UserException.class);
+    }
+
+    @DisplayName("경로 좌표에 요청 순서대로 sequence 0부터 부여된다")
+    @Test
+    @SuppressWarnings("unchecked")
+    void complete_경로포인트_시퀀스_부여() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        List<PloggingDto.RoutePointRequest> routePoints = List.of(
+                new PloggingDto.RoutePointRequest(37.1, 127.1),
+                new PloggingDto.RoutePointRequest(37.2, 127.2),
+                new PloggingDto.RoutePointRequest(37.3, 127.3)
+        );
+        PloggingDto.CompleteRequest request = buildRequest(routePoints, List.of());
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.save(any())).willAnswer(i -> i.getArgument(0));
+        given(ploggingPhotoRepository.saveAll(any())).willReturn(List.of());
+
+        ArgumentCaptor<List<PloggingRoutePoint>> captor = ArgumentCaptor.forClass(List.class);
+        given(ploggingRoutePointRepository.saveAll(captor.capture())).willReturn(List.of());
+
+        // when
+        ploggingService.complete(userId, request);
+
+        // then
+        List<PloggingRoutePoint> saved = captor.getValue();
+        assertThat(saved).hasSize(3);
+        assertThat(saved.get(0).getSequence()).isEqualTo(0);
+        assertThat(saved.get(1).getSequence()).isEqualTo(1);
+        assertThat(saved.get(2).getSequence()).isEqualTo(2);
+        assertThat(saved.get(0).getLatitude()).isEqualTo(37.1);
+        assertThat(saved.get(2).getLongitude()).isEqualTo(127.3);
+    }
+
+    @DisplayName("인증샷에 요청 순서대로 sequence 0부터 부여된다")
+    @Test
+    @SuppressWarnings("unchecked")
+    void complete_사진_시퀀스_부여() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        List<String> photoUrls = List.of(
+                "https://s3.example.com/photo0.jpg",
+                "https://s3.example.com/photo1.jpg"
+        );
+        PloggingDto.CompleteRequest request = buildRequest(List.of(), photoUrls);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.save(any())).willAnswer(i -> i.getArgument(0));
+        given(ploggingRoutePointRepository.saveAll(any())).willReturn(List.of());
+
+        ArgumentCaptor<List<PloggingPhoto>> captor = ArgumentCaptor.forClass(List.class);
+        given(ploggingPhotoRepository.saveAll(captor.capture())).willReturn(List.of());
+
+        // when
+        ploggingService.complete(userId, request);
+
+        // then
+        List<PloggingPhoto> saved = captor.getValue();
+        assertThat(saved).hasSize(2);
+        assertThat(saved.get(0).getSequence()).isEqualTo(0);
+        assertThat(saved.get(1).getSequence()).isEqualTo(1);
+        assertThat(saved.get(0).getImageUrl()).isEqualTo("https://s3.example.com/photo0.jpg");
+    }
+
+    @DisplayName("플로깅 완료 시 유저의 총 플로깅 시간이 갱신된다")
+    @Test
+    void complete_유저_플로깅시간_갱신() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        int ploggingSeconds = 600;
+        PloggingDto.CompleteRequest request = buildRequest(List.of(), List.of());
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.save(any())).willAnswer(i -> i.getArgument(0));
+        given(ploggingRoutePointRepository.saveAll(any())).willReturn(List.of());
+        given(ploggingPhotoRepository.saveAll(any())).willReturn(List.of());
+
+        // when
+        ploggingService.complete(userId, request);
+
+        // then
+        assertThat(user.getTotalPloggingSeconds()).isEqualTo(ploggingSeconds);
+    }
+
+    @DisplayName("경로 좌표와 인증샷이 없어도 정상 저장된다")
+    @Test
+    void complete_빈_목록_성공() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        PloggingDto.CompleteRequest request = buildRequest(List.of(), List.of());
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.save(any())).willAnswer(i -> i.getArgument(0));
+        given(ploggingRoutePointRepository.saveAll(any())).willReturn(List.of());
+        given(ploggingPhotoRepository.saveAll(any())).willReturn(List.of());
+
+        // when
+        PloggingDto.CompleteResponse result = ploggingService.complete(userId, request);
+
+        // then
+        assertThat(result.ploggingSessionId()).isNull();
+        verify(ploggingRoutePointRepository).saveAll(List.of());
+        verify(ploggingPhotoRepository).saveAll(List.of());
+    }
+
+    private PloggingDto.CompleteRequest buildRequest(
+            List<PloggingDto.RoutePointRequest> routePoints,
+            List<String> photoUrls
+    ) {
+        return new PloggingDto.CompleteRequest(
+                PloggingMode.FREE,
+                LocalDateTime.of(2026, 5, 3, 10, 0, 0),
+                LocalDateTime.of(2026, 5, 3, 10, 10, 0),
+                1500,
+                2000,
+                80,
+                600,
+                0,
+                "한강공원",
+                37.5, 127.0,
+                37.51, 127.01,
+                routePoints,
+                "https://s3.example.com/map.jpg",
+                photoUrls
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- close #13

## 작업 내용

### 도메인 엔티티

- `PloggingMode` enum 추가
  - `FREE`: 자유 플로깅
  - `RECOMMENDED`: 추천 경로 플로깅

- `PloggingSession` 엔티티 추가
  - 플로깅 완료 기록을 저장하는 메인 엔티티입니다.
  - 저장 항목
    - 플로깅 모드
    - 시작/종료 시간
    - 거리(m)
    - 걸음 수
    - 소모 칼로리
    - 플로깅 시간(초)
    - 휴식 시간(초)
    - 장소명
    - 시작/종료 좌표
    - 지도 이미지 URL
  - `User`와 `@ManyToOne` 관계를 가집니다.

- `PloggingRoutePoint` 엔티티 추가
  - 플로깅 경로 좌표를 저장합니다.
  - 요청으로 전달된 순서대로 `sequence` 값을 0부터 부여해 저장합니다.
  - `PloggingSession`과 `@ManyToOne` 관계를 가집니다.

- `PloggingPhoto` 엔티티 추가
  - 플로깅 인증샷 이미지 URL을 저장합니다.
  - 요청으로 전달된 순서대로 `sequence` 값을 0부터 부여해 저장합니다.
  - `PloggingSession`과 `@ManyToOne` 관계를 가집니다.

### Repository

- `PloggingSessionRepository` 추가
- `PloggingRoutePointRepository` 추가
- `PloggingPhotoRepository` 추가

### 예외

- `PloggingErrorCode` 추가
- `PloggingException` 추가
- 기존 `BusinessException` 기반 예외 처리 구조를 따르도록 구현했습니다.

### API

- `POST /api/plogging-sessions/complete` 추가
  - `@LoginUserId`를 통해 인증된 사용자 ID를 주입받습니다.
  - 플로깅 완료 데이터를 저장합니다.
  - 지도 이미지와 인증샷 이미지는 클라이언트가 S3에 직접 업로드한 뒤 URL만 서버에 전달합니다.
  - 지도 이미지와 인증샷 이미지 presigned 발급 로직은 다음 pr에 구현합니다.
  - 저장 완료 후 `user.addPloggingTimeSeconds()`를 호출해 유저의 총 플로깅 시간, 경험치, 레벨, 칭호를 갱신합니다.
  - 응답 예시

```json
{
  "ploggingSessionId": 1
}
```

### 버그 탐지 & 개선
- 로그인 했는데 500에러 뜨길래 왜 뜨는지 확인해 보았더니 기존에 만들었던 user의 title 필드에 default값 쓰봉이가 없었습니다.
- 그래서 값 넣어줘서 해결했고, 이와 관련해 `GlobalExceptionHandler`의 `Exception` 핸들러에 로깅이 없어 500 에러 발생 시 원인 파악이 어려웠던 문제를 수정했습니다.
  - `log.error()`를 통해 에러 클래스명, 메시지, 스택트레이스를 출력하도록 개선했습니다.

## 테스트

- [x] 로컬에서 플로깅 완료 기록 저장 API가 정상 동작하는 것을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트

- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.