### PR TITLE
[feat]: 플로깅 지도 및 인증샷 Presigned URL 발급 API 구현

### DIFF
--- a/.ai/code_convention.md
+++ b/.ai/code_convention.md
@@ -107,6 +107,10 @@ public class KakaoAuthException extends BusinessException {
 - 허용 Content-Type은 서버에서 검증하며, Presigned URL 서명 시에도 Content-Type을 고정한다.
 - `S3Client`와 `S3Presigner` 모두 `AwsCredentialsProvider` Bean을 공유한다.
 
+## import 규칙
+- 와일드카드 import(`import org.springframework.web.bind.annotation.*`)를 사용하지 않는다.
+- 항상 사용하는 클래스를 개별로 명시한다.
+
 ## 안티패턴 금지
 - Controller에서 Repository를 직접 호출하지 않는다.
 - `@Autowired` 필드 주입을 사용하지 않는다.

--- a/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
+++ b/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
@@ -1,6 +1,7 @@
 package com.flover.flover_be.plogging.controller;
 
 import com.flover.flover_be.global.auth.LoginUserId;
+import com.flover.flover_be.global.storage.StorageDto;
 import com.flover.flover_be.plogging.dto.PloggingDto;
 import com.flover.flover_be.plogging.service.PloggingService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,9 +9,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Plogging", description = "플로깅 API")
@@ -29,5 +32,25 @@ public class PloggingController {
             @RequestBody @Valid PloggingDto.CompleteRequest request
     ) {
         return ResponseEntity.ok(ploggingService.complete(userId, request));
+    }
+
+    @Operation(summary = "지도 이미지 업로드 URL 발급",
+            description = "플로깅 경로 지도 이미지를 S3에 직접 업로드하기 위한 Presigned URL을 발급합니다.")
+    @GetMapping("/map-image/upload-url")
+    public ResponseEntity<StorageDto.PresignedUploadUrlResponse> getMapImageUploadUrl(
+            @LoginUserId Long userId,
+            @RequestParam String contentType
+    ) {
+        return ResponseEntity.ok(ploggingService.generateMapImagePresignedUrl(userId, contentType));
+    }
+
+    @Operation(summary = "플로깅 인증샷 업로드 URL 발급",
+            description = "플로깅 인증샷을 S3에 직접 업로드하기 위한 Presigned URL을 발급합니다.")
+    @GetMapping("/photo/upload-url")
+    public ResponseEntity<StorageDto.PresignedUploadUrlResponse> getPhotoUploadUrl(
+            @LoginUserId Long userId,
+            @RequestParam String contentType
+    ) {
+        return ResponseEntity.ok(ploggingService.generatePhotoPresignedUrl(userId, contentType));
     }
 }

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -54,16 +54,21 @@ public class PloggingService {
         return new PloggingDto.CompleteResponse(savedSession.getId());
     }
 
+    @Transactional(readOnly = true)
     public StorageDto.PresignedUploadUrlResponse generateMapImagePresignedUrl(Long userId, String contentType) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        validateUserExists(userId);
         return ploggingStorageService.generateMapImagePresignedUrl(userId, contentType);
     }
 
+    @Transactional(readOnly = true)
     public StorageDto.PresignedUploadUrlResponse generatePhotoPresignedUrl(Long userId, String contentType) {
+        validateUserExists(userId);
+        return ploggingStorageService.generatePhotoPresignedUrl(userId, contentType);
+    }
+
+    private void validateUserExists(Long userId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-        return ploggingStorageService.generatePhotoPresignedUrl(userId, contentType);
     }
 
     private void saveRoutePoints(PloggingSession session, List<PloggingDto.RoutePointRequest> routePoints) {

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -1,5 +1,6 @@
 package com.flover.flover_be.plogging.service;
 
+import com.flover.flover_be.global.storage.StorageDto;
 import com.flover.flover_be.plogging.domain.PloggingPhoto;
 import com.flover.flover_be.plogging.domain.PloggingRoutePoint;
 import com.flover.flover_be.plogging.domain.PloggingSession;
@@ -26,6 +27,7 @@ public class PloggingService {
     private final PloggingSessionRepository ploggingSessionRepository;
     private final PloggingRoutePointRepository ploggingRoutePointRepository;
     private final PloggingPhotoRepository ploggingPhotoRepository;
+    private final PloggingStorageService ploggingStorageService;
 
     @Transactional
     public PloggingDto.CompleteResponse complete(Long userId, PloggingDto.CompleteRequest request) {
@@ -50,6 +52,18 @@ public class PloggingService {
         user.addPloggingTimeSeconds(request.ploggingSeconds());
 
         return new PloggingDto.CompleteResponse(savedSession.getId());
+    }
+
+    public StorageDto.PresignedUploadUrlResponse generateMapImagePresignedUrl(Long userId, String contentType) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        return ploggingStorageService.generateMapImagePresignedUrl(userId, contentType);
+    }
+
+    public StorageDto.PresignedUploadUrlResponse generatePhotoPresignedUrl(Long userId, String contentType) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        return ploggingStorageService.generatePhotoPresignedUrl(userId, contentType);
     }
 
     private void saveRoutePoints(PloggingSession session, List<PloggingDto.RoutePointRequest> routePoints) {

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingStorageService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingStorageService.java
@@ -9,15 +9,18 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PloggingStorageService {
 
+    private static final String MAP_IMAGE_PATH_TEMPLATE = "plogging/%d/maps";
+    private static final String PHOTO_PATH_TEMPLATE = "plogging/%d/photos";
+
     private final S3StorageService s3StorageService;
 
     public StorageDto.PresignedUploadUrlResponse generateMapImagePresignedUrl(Long userId, String contentType) {
         return s3StorageService.generatePresignedUploadUrl(
-                "plogging/%d/maps".formatted(userId), contentType);
+                MAP_IMAGE_PATH_TEMPLATE.formatted(userId), contentType);
     }
 
     public StorageDto.PresignedUploadUrlResponse generatePhotoPresignedUrl(Long userId, String contentType) {
         return s3StorageService.generatePresignedUploadUrl(
-                "plogging/%d/photos".formatted(userId), contentType);
+                PHOTO_PATH_TEMPLATE.formatted(userId), contentType);
     }
 }

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingStorageService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingStorageService.java
@@ -1,0 +1,23 @@
+package com.flover.flover_be.plogging.service;
+
+import com.flover.flover_be.global.storage.S3StorageService;
+import com.flover.flover_be.global.storage.StorageDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PloggingStorageService {
+
+    private final S3StorageService s3StorageService;
+
+    public StorageDto.PresignedUploadUrlResponse generateMapImagePresignedUrl(Long userId, String contentType) {
+        return s3StorageService.generatePresignedUploadUrl(
+                "plogging/%d/maps".formatted(userId), contentType);
+    }
+
+    public StorageDto.PresignedUploadUrlResponse generatePhotoPresignedUrl(Long userId, String contentType) {
+        return s3StorageService.generatePresignedUploadUrl(
+                "plogging/%d/photos".formatted(userId), contentType);
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/service/ProfileImageStorageService.java
+++ b/src/main/java/com/flover/flover_be/user/service/ProfileImageStorageService.java
@@ -9,11 +9,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ProfileImageStorageService {
 
+    private static final String PROFILE_IMAGE_PATH_TEMPLATE = "users/%d/profile";
+
     private final S3StorageService s3StorageService;
 
     public StorageDto.PresignedUploadUrlResponse generatePresignedUploadUrl(Long userId, String contentType) {
         return s3StorageService.generatePresignedUploadUrl(
-                "users/%d/profile".formatted(userId), contentType);
+                PROFILE_IMAGE_PATH_TEMPLATE.formatted(userId), contentType);
     }
 
     public void deleteIfOwnedByBucket(String objectUrl) {

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -37,6 +37,7 @@ public class UserService {
         return new UserDto.NicknameResponse(user.getId(), user.getNickname());
     }
 
+    @Transactional(readOnly = true)
     public StorageDto.PresignedUploadUrlResponse generateProfileImagePresignedUrl(Long userId, String contentType) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));


### PR DESCRIPTION
## 관련이슈
- close #15 

## 작업 내용

- `GET /api/plogging-sessions/map-image/upload-url`
  - 지도 이미지 S3 업로드용 Presigned URL 발급
- `GET /api/plogging-sessions/photo/upload-url`
  - 플로깅 인증샷 S3 업로드용 Presigned URL 발급
- S3 저장 경로 분리
  - 지도 이미지: `plogging/{userId}/maps/`
  - 인증샷: `plogging/{userId}/photos/`
- 이미지 파일은 클라이언트가 Presigned URL을 통해 S3에 직접 업로드
- 서버는 업로드 URL과 최종 이미지 URL을 응답
- 이미지 URL 저장은 기존 플로깅 완료 API에서 `mapImageUrl`, `photoUrls`를 전달받아 처리

## 테스트

- [x] 로컬에서 지도 이미지 Presigned URL 발급 API가 정상 동작하는 것을 확인했습니다.
- [x] 로컬에서 인증샷 Presigned URL 발급 API가 정상 동작하는 것을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트

- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.