### PR TITLE
Feat/plogging/get sessions

### DIFF
--- a/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
+++ b/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,10 +27,13 @@ public class PloggingController {
 
     private final PloggingService ploggingService;
 
-    @Operation(summary = "플로깅 기록 전체 조회", description = "로그인한 사용자의 플로깅 기록 목록을 최신순으로 반환합니다.")
+    @Operation(summary = "플로깅 기록 전체 조회", description = "로그인한 사용자의 플로깅 기록 목록을 최신순으로 반환합니다. 무한 스크롤을 위한 페이징을 지원합니다.")
     @GetMapping
-    public ResponseEntity<List<PloggingDto.SessionSummaryResponse>> getSessions(@LoginUserId Long userId) {
-        return ResponseEntity.ok(ploggingService.findSessions(userId));
+    public ResponseEntity<PloggingDto.SessionListResponse> getSessions(
+            @LoginUserId Long userId,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return ResponseEntity.ok(ploggingService.findSessions(userId, pageable));
     }
 
     @Operation(summary = "플로깅 완료 기록 저장",

--- a/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
+++ b/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class PloggingController {
 
     private final PloggingService ploggingService;
+
+    @Operation(summary = "플로깅 기록 전체 조회", description = "로그인한 사용자의 플로깅 기록 목록을 최신순으로 반환합니다.")
+    @GetMapping
+    public ResponseEntity<List<PloggingDto.SessionSummaryResponse>> getSessions(@LoginUserId Long userId) {
+        return ResponseEntity.ok(ploggingService.findSessions(userId));
+    }
 
     @Operation(summary = "플로깅 완료 기록 저장",
             description = "플로깅 완료 데이터를 저장합니다. 지도 이미지와 인증샷은 S3 URL로 전달합니다.")

--- a/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
+++ b/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
@@ -48,4 +48,9 @@ public class PloggingDto {
             LocalDateTime finishedAt,
             int distanceMeters
     ) {}
+
+    public record SessionListResponse(
+            List<SessionSummaryResponse> content,
+            boolean hasNext
+    ) {}
 }

--- a/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
+++ b/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
@@ -39,4 +39,13 @@ public class PloggingDto {
     ) {}
 
     public record CompleteResponse(Long ploggingSessionId) {}
+
+    public record SessionSummaryResponse(
+            Long ploggingSessionId,
+            PloggingMode mode,
+            String placeName,
+            LocalDateTime startedAt,
+            LocalDateTime finishedAt,
+            int distanceMeters
+    ) {}
 }

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
@@ -1,11 +1,11 @@
 package com.flover.flover_be.plogging.repository;
 
 import com.flover.flover_be.plogging.domain.PloggingSession;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface PloggingSessionRepository extends JpaRepository<PloggingSession, Long> {
 
-    List<PloggingSession> findAllByUserIdOrderByStartedAtDesc(Long userId);
+    Slice<PloggingSession> findAllByUserIdOrderByStartedAtDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
@@ -3,5 +3,9 @@ package com.flover.flover_be.plogging.repository;
 import com.flover.flover_be.plogging.domain.PloggingSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PloggingSessionRepository extends JpaRepository<PloggingSession, Long> {
+
+    List<PloggingSession> findAllByUserIdOrderByStartedAtDesc(Long userId);
 }

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -55,6 +55,21 @@ public class PloggingService {
     }
 
     @Transactional(readOnly = true)
+    public List<PloggingDto.SessionSummaryResponse> findSessions(Long userId) {
+        return ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId)
+                .stream()
+                .map(session -> new PloggingDto.SessionSummaryResponse(
+                        session.getId(),
+                        session.getMode(),
+                        session.getPlaceName(),
+                        session.getStartedAt(),
+                        session.getFinishedAt(),
+                        session.getDistanceMeters()
+                ))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
     public StorageDto.PresignedUploadUrlResponse generateMapImagePresignedUrl(Long userId, String contentType) {
         validateUserExists(userId);
         return ploggingStorageService.generateMapImagePresignedUrl(userId, contentType);

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -58,6 +58,7 @@ public class PloggingService {
 
     @Transactional(readOnly = true)
     public PloggingDto.SessionListResponse findSessions(Long userId, Pageable pageable) {
+        validateUserExists(userId);
         Slice<PloggingSession> slice = ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId, pageable);
         List<PloggingDto.SessionSummaryResponse> content = slice.getContent().stream()
                 .map(session -> new PloggingDto.SessionSummaryResponse(

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -1,6 +1,8 @@
 package com.flover.flover_be.plogging.service;
 
 import com.flover.flover_be.global.storage.StorageDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import com.flover.flover_be.plogging.domain.PloggingPhoto;
 import com.flover.flover_be.plogging.domain.PloggingRoutePoint;
 import com.flover.flover_be.plogging.domain.PloggingSession;
@@ -55,9 +57,9 @@ public class PloggingService {
     }
 
     @Transactional(readOnly = true)
-    public List<PloggingDto.SessionSummaryResponse> findSessions(Long userId) {
-        return ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId)
-                .stream()
+    public PloggingDto.SessionListResponse findSessions(Long userId, Pageable pageable) {
+        Slice<PloggingSession> slice = ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId, pageable);
+        List<PloggingDto.SessionSummaryResponse> content = slice.getContent().stream()
                 .map(session -> new PloggingDto.SessionSummaryResponse(
                         session.getId(),
                         session.getMode(),
@@ -67,6 +69,7 @@ public class PloggingService {
                         session.getDistanceMeters()
                 ))
                 .toList();
+        return new PloggingDto.SessionListResponse(content, slice.hasNext());
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
@@ -183,6 +183,54 @@ class PloggingServiceTest {
         verify(ploggingPhotoRepository).saveAll(List.of());
     }
 
+    @DisplayName("플로깅 기록 목록을 최신순으로 조회한다")
+    @Test
+    void find_sessions_성공() {
+        // given
+        Long userId = 1L;
+        LocalDateTime now = LocalDateTime.of(2026, 5, 4, 10, 0, 0);
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+
+        PloggingSession older = PloggingSession.create(
+                user, PloggingMode.FREE,
+                now.minusDays(1), now.minusDays(1).plusHours(1),
+                1000, 2000, 50, 300, 0, "장소A",
+                37.5, 127.0, 37.51, 127.01, null);
+        PloggingSession newer = PloggingSession.create(
+                user, PloggingMode.RECOMMENDED,
+                now, now.plusHours(1),
+                2000, 4000, 100, 600, 0, "장소B",
+                37.5, 127.0, 37.51, 127.01, null);
+
+        given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId))
+                .willReturn(List.of(newer, older));
+
+        // when
+        List<PloggingDto.SessionSummaryResponse> result = ploggingService.findSessions(userId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).placeName()).isEqualTo("장소B");
+        assertThat(result.get(1).placeName()).isEqualTo("장소A");
+        assertThat(result.get(0).mode()).isEqualTo(PloggingMode.RECOMMENDED);
+        assertThat(result.get(0).distanceMeters()).isEqualTo(2000);
+    }
+
+    @DisplayName("플로깅 기록이 없으면 빈 리스트를 반환한다")
+    @Test
+    void find_sessions_빈_결과() {
+        // given
+        Long userId = 1L;
+        given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId))
+                .willReturn(List.of());
+
+        // when
+        List<PloggingDto.SessionSummaryResponse> result = ploggingService.findSessions(userId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
     private PloggingDto.CompleteRequest buildRequest(
             List<PloggingDto.RoutePointRequest> routePoints,
             List<String> photoUrls

--- a/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
@@ -206,6 +206,7 @@ class PloggingServiceTest {
                 2000, 4000, 100, 600, 0, "장소B",
                 37.5, 127.0, 37.51, 127.01, null);
 
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId, pageable))
                 .willReturn(new SliceImpl<>(List.of(newer, older), pageable, false));
 
@@ -233,6 +234,7 @@ class PloggingServiceTest {
                 1000, 2000, 50, 300, 0, "장소A",
                 37.5, 127.0, 37.51, 127.01, null);
 
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId, pageable))
                 .willReturn(new SliceImpl<>(List.of(session), pageable, true));
 
@@ -243,12 +245,26 @@ class PloggingServiceTest {
         assertThat(result.hasNext()).isTrue();
     }
 
+    @DisplayName("존재하지 않는 유저로 플로깅 기록 조회 시 예외가 발생한다")
+    @Test
+    void find_sessions_유저없음_예외() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ploggingService.findSessions(1L, pageable))
+                .isInstanceOf(UserException.class);
+    }
+
     @DisplayName("플로깅 기록이 없으면 빈 리스트를 반환한다")
     @Test
     void find_sessions_빈_결과() {
         // given
         Long userId = 1L;
         Pageable pageable = PageRequest.of(0, 20);
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId, pageable))
                 .willReturn(new SliceImpl<>(List.of(), pageable, false));
 

--- a/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
@@ -11,6 +11,9 @@ import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.exception.UserException;
 import com.flover.flover_be.user.repository.UserRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -188,6 +191,7 @@ class PloggingServiceTest {
     void find_sessions_성공() {
         // given
         Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 20);
         LocalDateTime now = LocalDateTime.of(2026, 5, 4, 10, 0, 0);
         User user = User.create(12345L, "test@test.com", "닉네임", null);
 
@@ -202,18 +206,41 @@ class PloggingServiceTest {
                 2000, 4000, 100, 600, 0, "장소B",
                 37.5, 127.0, 37.51, 127.01, null);
 
-        given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId))
-                .willReturn(List.of(newer, older));
+        given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId, pageable))
+                .willReturn(new SliceImpl<>(List.of(newer, older), pageable, false));
 
         // when
-        List<PloggingDto.SessionSummaryResponse> result = ploggingService.findSessions(userId);
+        PloggingDto.SessionListResponse result = ploggingService.findSessions(userId, pageable);
 
         // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).placeName()).isEqualTo("장소B");
-        assertThat(result.get(1).placeName()).isEqualTo("장소A");
-        assertThat(result.get(0).mode()).isEqualTo(PloggingMode.RECOMMENDED);
-        assertThat(result.get(0).distanceMeters()).isEqualTo(2000);
+        assertThat(result.content()).hasSize(2);
+        assertThat(result.content().get(0).placeName()).isEqualTo("장소B");
+        assertThat(result.content().get(1).placeName()).isEqualTo("장소A");
+        assertThat(result.content().get(0).mode()).isEqualTo(PloggingMode.RECOMMENDED);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @DisplayName("다음 페이지가 있으면 hasNext가 true다")
+    @Test
+    void find_sessions_hasNext_true() {
+        // given
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 1);
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        PloggingSession session = PloggingSession.create(
+                user, PloggingMode.FREE,
+                LocalDateTime.now(), LocalDateTime.now().plusHours(1),
+                1000, 2000, 50, 300, 0, "장소A",
+                37.5, 127.0, 37.51, 127.01, null);
+
+        given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId, pageable))
+                .willReturn(new SliceImpl<>(List.of(session), pageable, true));
+
+        // when
+        PloggingDto.SessionListResponse result = ploggingService.findSessions(userId, pageable);
+
+        // then
+        assertThat(result.hasNext()).isTrue();
     }
 
     @DisplayName("플로깅 기록이 없으면 빈 리스트를 반환한다")
@@ -221,14 +248,16 @@ class PloggingServiceTest {
     void find_sessions_빈_결과() {
         // given
         Long userId = 1L;
-        given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId))
-                .willReturn(List.of());
+        Pageable pageable = PageRequest.of(0, 20);
+        given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId, pageable))
+                .willReturn(new SliceImpl<>(List.of(), pageable, false));
 
         // when
-        List<PloggingDto.SessionSummaryResponse> result = ploggingService.findSessions(userId);
+        PloggingDto.SessionListResponse result = ploggingService.findSessions(userId, pageable);
 
         // then
-        assertThat(result).isEmpty();
+        assertThat(result.content()).isEmpty();
+        assertThat(result.hasNext()).isFalse();
     }
 
     private PloggingDto.CompleteRequest buildRequest(


### PR DESCRIPTION
## 관련 이슈
- close #17 

## 작업 내용
- `GET /api/plogging-sessions` API 구현
- 로그인한 사용자의 플로깅 기록 목록을 `startedAt` 내림차순(최신순)으로 반환
- 응답 항목
  - `ploggingSessionId`
  - `mode`
  - `placeName`
  - `startedAt`
  - `finishedAt`
  - `distanceMeters`
- `mapImageUrl`, `routePoints`, `photoUrls` 등 리스트 화면에 불필요한 데이터는 응답에서 제외
- `PloggingSessionRepository`에 `findAllByUserIdOrderByStartedAtDesc` 쿼리 메서드 추가
- Slice 기반 무한스크롤 구현
  - Slice 기반 페이징으로 count 쿼리 없이 다음 페이지 존재 여부만 확인
  - 기본 페이지 크기 20 (@PageableDefault(size = 20))                                                                                                - 응답: { "content": [...], "hasNext": true/false }
  - 클라이언트는 ?page=0&size=20 쿼리 파라미터로 페이지 요청                                                                                       
    
## 테스트
- [x] 로컬에서 플로깅 기록 전체 조회 API가 정상 동작하는 것을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.

## 참고
### <img width="782" height="580" alt="image" src="https://github.com/user-attachments/assets/126acb25-a9a2-490a-a065-a99a5f351a41" />
현재 반환값이 들어갈 화면입니다

### <img width="453" height="713" alt="image" src="https://github.com/user-attachments/assets/2ce55910-e9fd-4ee3-ad42-3b465bcb9867" />

테스트 응답사진입니다