### PR TITLE
[feat]: 플로깅 기록 단건 조회 API 구현

### DIFF
--- a/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
+++ b/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
@@ -13,6 +13,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,6 +35,15 @@ public class PloggingController {
             @PageableDefault(size = 20) Pageable pageable
     ) {
         return ResponseEntity.ok(ploggingService.findSessions(userId, pageable));
+    }
+
+    @Operation(summary = "플로깅 기록 단건 조회", description = "로그인한 사용자의 특정 플로깅 기록 상세 정보를 조회합니다.")
+    @GetMapping("/{ploggingSessionId}")
+    public ResponseEntity<PloggingDto.SessionDetailResponse> getSession(
+            @LoginUserId Long userId,
+            @PathVariable Long ploggingSessionId
+    ) {
+        return ResponseEntity.ok(ploggingService.findSession(userId, ploggingSessionId));
     }
 
     @Operation(summary = "플로깅 완료 기록 저장",

--- a/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
+++ b/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
@@ -53,4 +53,19 @@ public class PloggingDto {
             List<SessionSummaryResponse> content,
             boolean hasNext
     ) {}
+
+    public record SessionDetailResponse(
+            Long ploggingSessionId,
+            PloggingMode mode,
+            LocalDateTime startedAt,
+            LocalDateTime finishedAt,
+            String placeName,
+            int distanceMeters,
+            int stepCount,
+            int caloriesBurned,
+            int ploggingSeconds,
+            int restSeconds,
+            String mapImageUrl,
+            List<String> photoUrls
+    ) {}
 }

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingPhotoRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingPhotoRepository.java
@@ -3,5 +3,9 @@ package com.flover.flover_be.plogging.repository;
 import com.flover.flover_be.plogging.domain.PloggingPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PloggingPhotoRepository extends JpaRepository<PloggingPhoto, Long> {
+
+    List<PloggingPhoto> findAllByPloggingSessionIdOrderBySequenceAsc(Long ploggingSessionId);
 }

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
@@ -5,7 +5,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PloggingSessionRepository extends JpaRepository<PloggingSession, Long> {
 
     Slice<PloggingSession> findAllByUserIdOrderByStartedAtDesc(Long userId, Pageable pageable);
+
+    Optional<PloggingSession> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -77,6 +77,7 @@ public class PloggingService {
 
     @Transactional(readOnly = true)
     public PloggingDto.SessionDetailResponse findSession(Long userId, Long ploggingSessionId) {
+        validateUserExists(userId);
         PloggingSession session = ploggingSessionRepository.findByIdAndUserId(ploggingSessionId, userId)
                 .orElseThrow(() -> new PloggingException(PloggingErrorCode.PLOGGING_SESSION_NOT_FOUND));
         List<String> photoUrls = ploggingPhotoRepository

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -7,6 +7,8 @@ import com.flover.flover_be.plogging.domain.PloggingPhoto;
 import com.flover.flover_be.plogging.domain.PloggingRoutePoint;
 import com.flover.flover_be.plogging.domain.PloggingSession;
 import com.flover.flover_be.plogging.dto.PloggingDto;
+import com.flover.flover_be.plogging.exception.PloggingErrorCode;
+import com.flover.flover_be.plogging.exception.PloggingException;
 import com.flover.flover_be.plogging.repository.PloggingPhotoRepository;
 import com.flover.flover_be.plogging.repository.PloggingRoutePointRepository;
 import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
@@ -71,6 +73,31 @@ public class PloggingService {
                 ))
                 .toList();
         return new PloggingDto.SessionListResponse(content, slice.hasNext());
+    }
+
+    @Transactional(readOnly = true)
+    public PloggingDto.SessionDetailResponse findSession(Long userId, Long ploggingSessionId) {
+        PloggingSession session = ploggingSessionRepository.findByIdAndUserId(ploggingSessionId, userId)
+                .orElseThrow(() -> new PloggingException(PloggingErrorCode.PLOGGING_SESSION_NOT_FOUND));
+        List<String> photoUrls = ploggingPhotoRepository
+                .findAllByPloggingSessionIdOrderBySequenceAsc(ploggingSessionId)
+                .stream()
+                .map(PloggingPhoto::getImageUrl)
+                .toList();
+        return new PloggingDto.SessionDetailResponse(
+                session.getId(),
+                session.getMode(),
+                session.getStartedAt(),
+                session.getFinishedAt(),
+                session.getPlaceName(),
+                session.getDistanceMeters(),
+                session.getStepCount(),
+                session.getCaloriesBurned(),
+                session.getPloggingSeconds(),
+                session.getRestSeconds(),
+                session.getMapImageUrl(),
+                photoUrls
+        );
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
@@ -5,6 +5,7 @@ import com.flover.flover_be.plogging.domain.PloggingPhoto;
 import com.flover.flover_be.plogging.domain.PloggingRoutePoint;
 import com.flover.flover_be.plogging.domain.PloggingSession;
 import com.flover.flover_be.plogging.dto.PloggingDto;
+import com.flover.flover_be.plogging.exception.PloggingException;
 import com.flover.flover_be.plogging.repository.PloggingPhotoRepository;
 import com.flover.flover_be.plogging.repository.PloggingRoutePointRepository;
 import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
@@ -274,6 +275,96 @@ class PloggingServiceTest {
         // then
         assertThat(result.content()).isEmpty();
         assertThat(result.hasNext()).isFalse();
+    }
+
+    @DisplayName("플로깅 기록 단건 조회 시 상세 정보를 반환한다")
+    @Test
+    void find_session_성공() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 10L;
+        LocalDateTime startedAt = LocalDateTime.of(2026, 5, 4, 10, 0, 0);
+        LocalDateTime finishedAt = LocalDateTime.of(2026, 5, 4, 10, 30, 0);
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+
+        PloggingSession session = PloggingSession.create(
+                user, PloggingMode.FREE,
+                startedAt, finishedAt,
+                3000, 4000, 150, 1800, 120,
+                "한강공원", 37.5, 127.0, 37.52, 127.02,
+                "https://s3.example.com/map.jpg"
+        );
+
+        PloggingPhoto photo1 = PloggingPhoto.create(session, 0, "https://s3.example.com/photo0.jpg");
+        PloggingPhoto photo2 = PloggingPhoto.create(session, 1, "https://s3.example.com/photo1.jpg");
+
+        given(ploggingSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(ploggingPhotoRepository.findAllByPloggingSessionIdOrderBySequenceAsc(sessionId))
+                .willReturn(List.of(photo1, photo2));
+
+        // when
+        PloggingDto.SessionDetailResponse result = ploggingService.findSession(userId, sessionId);
+
+        // then
+        assertThat(result.mode()).isEqualTo(PloggingMode.FREE);
+        assertThat(result.startedAt()).isEqualTo(startedAt);
+        assertThat(result.finishedAt()).isEqualTo(finishedAt);
+        assertThat(result.placeName()).isEqualTo("한강공원");
+        assertThat(result.distanceMeters()).isEqualTo(3000);
+        assertThat(result.stepCount()).isEqualTo(4000);
+        assertThat(result.caloriesBurned()).isEqualTo(150);
+        assertThat(result.ploggingSeconds()).isEqualTo(1800);
+        assertThat(result.restSeconds()).isEqualTo(120);
+        assertThat(result.mapImageUrl()).isEqualTo("https://s3.example.com/map.jpg");
+        assertThat(result.photoUrls()).containsExactly(
+                "https://s3.example.com/photo0.jpg",
+                "https://s3.example.com/photo1.jpg"
+        );
+    }
+
+    @DisplayName("존재하지 않거나 본인 기록이 아닌 플로깅 세션 조회 시 예외가 발생한다")
+    @Test
+    void find_session_없거나_타인기록_예외() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 999L;
+        given(ploggingSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ploggingService.findSession(userId, sessionId))
+                .isInstanceOf(PloggingException.class);
+    }
+
+    @DisplayName("인증샷 URL이 sequence 오름차순으로 반환된다")
+    @Test
+    void find_session_인증샷_sequence_순서() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 10L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        PloggingSession session = PloggingSession.create(
+                user, PloggingMode.FREE,
+                LocalDateTime.of(2026, 5, 4, 9, 0, 0), LocalDateTime.of(2026, 5, 4, 9, 30, 0),
+                1000, 2000, 80, 600, 0,
+                "공원", 37.5, 127.0, 37.51, 127.01, null
+        );
+
+        PloggingPhoto first = PloggingPhoto.create(session, 0, "https://s3.example.com/first.jpg");
+        PloggingPhoto second = PloggingPhoto.create(session, 1, "https://s3.example.com/second.jpg");
+        PloggingPhoto third = PloggingPhoto.create(session, 2, "https://s3.example.com/third.jpg");
+
+        given(ploggingSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
+        given(ploggingPhotoRepository.findAllByPloggingSessionIdOrderBySequenceAsc(sessionId))
+                .willReturn(List.of(first, second, third));
+
+        // when
+        PloggingDto.SessionDetailResponse result = ploggingService.findSession(userId, sessionId);
+
+        // then
+        assertThat(result.photoUrls()).hasSize(3);
+        assertThat(result.photoUrls().get(0)).isEqualTo("https://s3.example.com/first.jpg");
+        assertThat(result.photoUrls().get(1)).isEqualTo("https://s3.example.com/second.jpg");
+        assertThat(result.photoUrls().get(2)).isEqualTo("https://s3.example.com/third.jpg");
     }
 
     private PloggingDto.CompleteRequest buildRequest(

--- a/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
@@ -298,6 +298,7 @@ class PloggingServiceTest {
         PloggingPhoto photo1 = PloggingPhoto.create(session, 0, "https://s3.example.com/photo0.jpg");
         PloggingPhoto photo2 = PloggingPhoto.create(session, 1, "https://s3.example.com/photo1.jpg");
 
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(ploggingSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
         given(ploggingPhotoRepository.findAllByPloggingSessionIdOrderBySequenceAsc(sessionId))
                 .willReturn(List.of(photo1, photo2));
@@ -328,6 +329,8 @@ class PloggingServiceTest {
         // given
         Long userId = 1L;
         Long sessionId = 999L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(ploggingSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.empty());
 
         // when & then
@@ -353,6 +356,7 @@ class PloggingServiceTest {
         PloggingPhoto second = PloggingPhoto.create(session, 1, "https://s3.example.com/second.jpg");
         PloggingPhoto third = PloggingPhoto.create(session, 2, "https://s3.example.com/third.jpg");
 
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(ploggingSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.of(session));
         given(ploggingPhotoRepository.findAllByPloggingSessionIdOrderBySequenceAsc(sessionId))
                 .willReturn(List.of(first, second, third));


### PR DESCRIPTION
## 관련 이슈
- close #19 

## 작업 내용
- `GET /api/plogging-sessions/{ploggingSessionId}` 단건 조회 API 구현                                                                             
- `@LoginUserId`로 인증된 사용자 ID와 `ploggingSessionId`를 함께 검증해 본인 기록만 조회 가능하도록 제한            
- `PloggingSessionRepository`에 `findByIdAndUserId` 추가 — 존재 여부와 소유권을 단일 쿼리로 검증
- `PloggingPhotoRepository`에 `findAllByPloggingSessionIdOrderBySequenceAsc` 추가 — 인증샷을 sequence 오름차순으로 조회
- `SessionDetailResponse` DTO 추가 — 상세 화면에 필요한 전체 필드(거리, 걸음 수, 칼로리, 플로깅 시간, 휴식 시간, 지도 이미지, 인증샷 목록) 반환   

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.
  - 정상 단건 조회 시 전체 필드가 올바르게 반환되는 경우
  - 존재하지 않거나 본인 기록이 아닐 때 `PloggingException` 발생하는 경우
  - 인증샷 URL이 sequence 오름차순으로 반환되는 경우

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.

## 참고
<img width="634" height="411" alt="image" src="https://github.com/user-attachments/assets/57c0fab9-3116-4e02-9e20-d5a78dece07a" />
