### PR TITLE
[feat]: 마이페이지 플로깅 누적 통계 조회 API 구현

### DIFF
--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
@@ -15,11 +15,12 @@ public interface PloggingSessionRepository extends JpaRepository<PloggingSession
 
     Optional<PloggingSession> findByIdAndUserId(Long id, Long userId);
 
-    long countByUserId(Long userId);
+    @Query("SELECT COUNT(p) AS count, COALESCE(SUM(p.stepCount), 0) AS totalStepCount, COALESCE(SUM(p.distanceMeters), 0) AS totalDistanceMeters FROM PloggingSession p WHERE p.user.id = :userId")
+    PloggingStatsView findStatsByUserId(@Param("userId") Long userId);
 
-    @Query("SELECT COALESCE(SUM(p.stepCount), 0) FROM PloggingSession p WHERE p.user.id = :userId")
-    long sumStepCountByUserId(@Param("userId") Long userId);
-
-    @Query("SELECT COALESCE(SUM(p.distanceMeters), 0) FROM PloggingSession p WHERE p.user.id = :userId")
-    long sumDistanceByUserId(@Param("userId") Long userId);
+    interface PloggingStatsView {
+        long getCount();
+        long getTotalStepCount();
+        long getTotalDistanceMeters();
+    }
 }

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
@@ -4,6 +4,8 @@ import com.flover.flover_be.plogging.domain.PloggingSession;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +14,12 @@ public interface PloggingSessionRepository extends JpaRepository<PloggingSession
     Slice<PloggingSession> findAllByUserIdOrderByStartedAtDesc(Long userId, Pageable pageable);
 
     Optional<PloggingSession> findByIdAndUserId(Long id, Long userId);
+
+    long countByUserId(Long userId);
+
+    @Query("SELECT COALESCE(SUM(p.stepCount), 0) FROM PloggingSession p WHERE p.user.id = :userId")
+    long sumStepCountByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT COALESCE(SUM(p.distanceMeters), 0) FROM PloggingSession p WHERE p.user.id = :userId")
+    long sumDistanceByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/flover/flover_be/user/controller/UserController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/UserController.java
@@ -10,7 +10,13 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User", description = "사용자 API")
 @RestController
@@ -24,6 +30,13 @@ public class UserController {
     @GetMapping("/{userId}")
     public ResponseEntity<UserDto.UserInfoResponse> getUserInfo(@PathVariable @Positive Long userId) {
         return ResponseEntity.ok(userService.findUserInfo(userId));
+    }
+
+    @Operation(summary = "플로깅 누적 통계 조회",
+            description = "마이페이지용 로그인 사용자의 총 플로깅 횟수, 걸음 수, 거리를 반환합니다.")
+    @GetMapping("/me/plogging-stats")
+    public ResponseEntity<UserDto.PloggingStatsResponse> getPloggingStats(@LoginUserId Long userId) {
+        return ResponseEntity.ok(userService.findPloggingStats(userId));
     }
 
     @Operation(summary = "닉네임 수정", description = "사용자 닉네임 변경")

--- a/src/main/java/com/flover/flover_be/user/dto/UserDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/UserDto.java
@@ -13,4 +13,10 @@ public class UserDto {
     public record ProfileImageUrlRequest(@NotBlank String imageUrl) {}
 
     public record UserInfoResponse(String nickname, int level, String title, String profileImageUrl) {}
+
+    public record PloggingStatsResponse(
+            long totalPloggingCount,
+            long totalStepCount,
+            long totalDistanceMeters
+    ) {}
 }

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -21,15 +21,13 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserDto.UserInfoResponse findUserInfo(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        User user = getUserOrThrow(userId);
         return new UserDto.UserInfoResponse(user.getNickname(), user.getLevel(), user.getTitle().getDisplayName(), user.getProfileImageUrl());
     }
 
     @Transactional
     public UserDto.NicknameResponse updateNickname(Long userId, String nickname) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        User user = getUserOrThrow(userId);
 
         if (!nickname.equals(user.getNickname()) && userRepository.existsByNickname(nickname)) {
             throw new UserException(UserErrorCode.NICKNAME_ALREADY_USED);
@@ -41,15 +39,13 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public StorageDto.PresignedUploadUrlResponse generateProfileImagePresignedUrl(Long userId, String contentType) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        getUserOrThrow(userId);
         return profileImageStorageService.generatePresignedUploadUrl(userId, contentType);
     }
 
     @Transactional(readOnly = true)
     public UserDto.PloggingStatsResponse findPloggingStats(Long userId) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        getUserOrThrow(userId);
         long count = ploggingSessionRepository.countByUserId(userId);
         long totalStepCount = ploggingSessionRepository.sumStepCountByUserId(userId);
         long totalDistanceMeters = ploggingSessionRepository.sumDistanceByUserId(userId);
@@ -58,12 +54,16 @@ public class UserService {
 
     @Transactional
     public UserDto.ProfileImageResponse saveProfileImageUrl(Long userId, String imageUrl) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        User user = getUserOrThrow(userId);
         if (user.getProfileImageUrl() != null && !user.getProfileImageUrl().equals(imageUrl)) {
             profileImageStorageService.deleteIfOwnedByBucket(user.getProfileImageUrl());
         }
         user.updateProfileImage(imageUrl);
         return new UserDto.ProfileImageResponse(user.getId(), user.getProfileImageUrl());
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -46,10 +46,8 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserDto.PloggingStatsResponse findPloggingStats(Long userId) {
         getUserOrThrow(userId);
-        long count = ploggingSessionRepository.countByUserId(userId);
-        long totalStepCount = ploggingSessionRepository.sumStepCountByUserId(userId);
-        long totalDistanceMeters = ploggingSessionRepository.sumDistanceByUserId(userId);
-        return new UserDto.PloggingStatsResponse(count, totalStepCount, totalDistanceMeters);
+        PloggingSessionRepository.PloggingStatsView stats = ploggingSessionRepository.findStatsByUserId(userId);
+        return new UserDto.PloggingStatsResponse(stats.getCount(), stats.getTotalStepCount(), stats.getTotalDistanceMeters());
     }
 
     @Transactional

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.flover.flover_be.user.service;
 
 import com.flover.flover_be.global.storage.StorageDto;
+import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.dto.UserDto;
 import com.flover.flover_be.user.exception.UserErrorCode;
@@ -16,6 +17,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final ProfileImageStorageService profileImageStorageService;
+    private final PloggingSessionRepository ploggingSessionRepository;
 
     @Transactional(readOnly = true)
     public UserDto.UserInfoResponse findUserInfo(Long userId) {
@@ -42,6 +44,16 @@ public class UserService {
         userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
         return profileImageStorageService.generatePresignedUploadUrl(userId, contentType);
+    }
+
+    @Transactional(readOnly = true)
+    public UserDto.PloggingStatsResponse findPloggingStats(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        long count = ploggingSessionRepository.countByUserId(userId);
+        long totalStepCount = ploggingSessionRepository.sumStepCountByUserId(userId);
+        long totalDistanceMeters = ploggingSessionRepository.sumDistanceByUserId(userId);
+        return new UserDto.PloggingStatsResponse(count, totalStepCount, totalDistanceMeters);
     }
 
     @Transactional

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.flover.flover_be.user.service;
 
 import com.flover.flover_be.global.storage.StorageDto;
 import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
+import com.flover.flover_be.plogging.repository.PloggingSessionRepository.PloggingStatsView;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.dto.UserDto;
 import com.flover.flover_be.user.exception.UserErrorCode;
@@ -231,11 +232,10 @@ class UserServiceTest {
         // given
         Long userId = 1L;
         User user = User.create(12345L, "test@test.com", "닉네임", null);
+        PloggingStatsView stats = mockStats(3L, 12000L, 8500L);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(ploggingSessionRepository.countByUserId(userId)).willReturn(3L);
-        given(ploggingSessionRepository.sumStepCountByUserId(userId)).willReturn(12000L);
-        given(ploggingSessionRepository.sumDistanceByUserId(userId)).willReturn(8500L);
+        given(ploggingSessionRepository.findStatsByUserId(userId)).willReturn(stats);
 
         // when
         UserDto.PloggingStatsResponse result = userService.findPloggingStats(userId);
@@ -252,11 +252,10 @@ class UserServiceTest {
         // given
         Long userId = 1L;
         User user = User.create(12345L, "test@test.com", "닉네임", null);
+        PloggingStatsView stats = mockStats(0L, 0L, 0L);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(ploggingSessionRepository.countByUserId(userId)).willReturn(0L);
-        given(ploggingSessionRepository.sumStepCountByUserId(userId)).willReturn(0L);
-        given(ploggingSessionRepository.sumDistanceByUserId(userId)).willReturn(0L);
+        given(ploggingSessionRepository.findStatsByUserId(userId)).willReturn(stats);
 
         // when
         UserDto.PloggingStatsResponse result = userService.findPloggingStats(userId);
@@ -276,5 +275,13 @@ class UserServiceTest {
         // when & then
         assertThatThrownBy(() -> userService.findPloggingStats(1L))
                 .isInstanceOf(UserException.class);
+    }
+
+    private PloggingStatsView mockStats(long count, long totalStepCount, long totalDistanceMeters) {
+        return new PloggingStatsView() {
+            public long getCount() { return count; }
+            public long getTotalStepCount() { return totalStepCount; }
+            public long getTotalDistanceMeters() { return totalDistanceMeters; }
+        };
     }
 }

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.flover.flover_be.user.service;
 
 import com.flover.flover_be.global.storage.StorageDto;
+import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.dto.UserDto;
 import com.flover.flover_be.user.exception.UserErrorCode;
@@ -29,6 +30,7 @@ class UserServiceTest {
 
     @Mock private UserRepository userRepository;
     @Mock private ProfileImageStorageService profileImageStorageService;
+    @Mock private PloggingSessionRepository ploggingSessionRepository;
     @InjectMocks private UserService userService;
 
     @DisplayName("유저 정보를 정상적으로 조회한다")
@@ -220,6 +222,59 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.saveProfileImageUrl(1L, "https://example.com/img.png"))
+                .isInstanceOf(UserException.class);
+    }
+
+    @DisplayName("플로깅 기록이 있는 사용자의 누적 통계를 반환한다")
+    @Test
+    void find_plogging_stats_성공() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.countByUserId(userId)).willReturn(3L);
+        given(ploggingSessionRepository.sumStepCountByUserId(userId)).willReturn(12000L);
+        given(ploggingSessionRepository.sumDistanceByUserId(userId)).willReturn(8500L);
+
+        // when
+        UserDto.PloggingStatsResponse result = userService.findPloggingStats(userId);
+
+        // then
+        assertThat(result.totalPloggingCount()).isEqualTo(3L);
+        assertThat(result.totalStepCount()).isEqualTo(12000L);
+        assertThat(result.totalDistanceMeters()).isEqualTo(8500L);
+    }
+
+    @DisplayName("플로깅 기록이 없는 사용자는 모든 통계가 0이다")
+    @Test
+    void find_plogging_stats_기록없음_모두_0() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.countByUserId(userId)).willReturn(0L);
+        given(ploggingSessionRepository.sumStepCountByUserId(userId)).willReturn(0L);
+        given(ploggingSessionRepository.sumDistanceByUserId(userId)).willReturn(0L);
+
+        // when
+        UserDto.PloggingStatsResponse result = userService.findPloggingStats(userId);
+
+        // then
+        assertThat(result.totalPloggingCount()).isZero();
+        assertThat(result.totalStepCount()).isZero();
+        assertThat(result.totalDistanceMeters()).isZero();
+    }
+
+    @DisplayName("존재하지 않는 유저의 플로깅 통계 조회 시 예외가 발생한다")
+    @Test
+    void find_plogging_stats_유저없음_예외() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.findPloggingStats(1L))
                 .isInstanceOf(UserException.class);
     }
 }


### PR DESCRIPTION
## 관련 이슈
- close #21 

## 작업 내용
- `GET /api/users/me/plogging-stats` 플로깅 누적 통계 조회 API 구현
- `@LoginUserId`로 인증된 사용자 본인의 통계만 조회되도록 `userId` 조건 적용
- `PloggingSessionRepository`에 집계 쿼리 추가
  - `countByUserId`: 총 플로깅 횟수 조회
  - `sumStepCountByUserId`: 총 걸음 수 조회
  - `sumDistanceByUserId`: 총 거리(m) 조회
- `SUM` 결과가 `null`인 경우 `COALESCE`를 사용해 0으로 반환되도록 처리
- `UserDto.PloggingStatsResponse` 응답 DTO 추가
  - `totalPloggingCount`
  - `totalStepCount`
  - `totalDistanceMeters`
- `UserService`에 `findPloggingStats()` 메서드 추가
- 반복되던 유저 조회 로직을 `getUserOrThrow()`로 추출

## 테스트
- [x] 로컬에서 플로깅 누적 통계 조회 API가 정상 동작하는 것을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.
  - 플로깅 기록이 있는 사용자의 통계가 올바르게 반환되는 경우
  - 플로깅 기록이 없는 사용자는 모든 값이 0으로 반환되는 경우
  - 존재하지 않는 유저 조회 시 `UserException`이 발생하는 경우

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.

## 참고

### postman test
<img width="345" height="195" alt="image" src="https://github.com/user-attachments/assets/5f1d0102-c97a-4d6d-b9c5-e3a2e3da704a" />

### 정보가 들어가는 화면 (검은동그라미 친 부분)
<img width="305" height="638" alt="image" src="https://github.com/user-attachments/assets/73f075e3-4fe2-475b-a6b0-14c321209585" />
