### PR TITLE
[feat]: 월간 및 주간 플로깅 통계 조회 API 구현

### DIFF
--- a/.ai/code_convention.md
+++ b/.ai/code_convention.md
@@ -111,6 +111,45 @@ public class KakaoAuthException extends BusinessException {
 - 와일드카드 import(`import org.springframework.web.bind.annotation.*`)를 사용하지 않는다.
 - 항상 사용하는 클래스를 개별로 명시한다.
 
+## JPQL 집계 쿼리 패턴
+- 여러 집계값을 조회할 때 쿼리를 여러 번 나눠 호출하지 않는다. 단일 JPQL 쿼리로 한 번에 가져온다.
+- 결과는 **인터페이스 기반 프로젝션(interface-based projection)** 으로 받는다. 엔티티 전체를 로드하지 않는다.
+- 프로젝션 인터페이스는 사용하는 Repository 인터페이스 내부에 중첩 인터페이스로 선언한다.
+- `SUM` 집계는 레코드가 없을 때 `null`을 반환하므로 `COALESCE`로 0 처리한다.
+
+```java
+// Repository
+@Query("SELECT COUNT(p) AS count, COALESCE(SUM(p.stepCount), 0) AS totalStepCount, COALESCE(SUM(p.distanceMeters), 0) AS totalDistanceMeters FROM PloggingSession p WHERE p.user.id = :userId")
+PloggingStatsView findStatsByUserId(@Param("userId") Long userId);
+
+interface PloggingStatsView {
+    long getCount();
+    long getTotalStepCount();
+    long getTotalDistanceMeters();
+}
+```
+
+## 서비스 내 다중 필드 집계 패턴
+- 컬렉션에서 여러 필드를 합산할 때 필드마다 스트림을 별도로 순회하지 않는다.
+- `private record`를 서비스 클래스 내부에 선언하고 정적 팩토리 메서드(`from`)에서 단일 루프로 모든 필드를 집계한다.
+- 월간/주간처럼 동일한 집계가 여러 곳에서 필요한 경우 이 record를 공통으로 재사용한다.
+
+```java
+// Service 내부
+private record SessionAggregate(long stepCount, long distanceMeters, long caloriesBurned, long ploggingSeconds) {
+    static SessionAggregate from(List<SessionStatsView> sessions) {
+        long stepCount = 0, distanceMeters = 0, caloriesBurned = 0, ploggingSeconds = 0;
+        for (SessionStatsView s : sessions) {
+            stepCount += s.getStepCount();
+            distanceMeters += s.getDistanceMeters();
+            caloriesBurned += s.getCaloriesBurned();
+            ploggingSeconds += s.getPloggingSeconds();
+        }
+        return new SessionAggregate(stepCount, distanceMeters, caloriesBurned, ploggingSeconds);
+    }
+}
+```
+
 ## 안티패턴 금지
 - Controller에서 Repository를 직접 호출하지 않는다.
 - `@Autowired` 필드 주입을 사용하지 않는다.
@@ -119,3 +158,4 @@ public class KakaoAuthException extends BusinessException {
 - 엔티티에 public setter를 사용하지 않는다.
 - 상태 변경은 의미 있는 도메인 메서드를 통해 수행한다. (예: changePassword)
 - `IllegalArgumentException`, `IllegalStateException` 등 표준 Java 예외를 도메인 로직에서 직접 던지지 않는다. 도메인 엔티티 내부에서도 커스텀 `BusinessException` 서브클래스를 사용한다.
+- 동일한 컬렉션을 필드별로 여러 번 순회해 집계하지 않는다. 단일 루프 또는 `private record`로 한 번에 처리한다.

--- a/src/main/java/com/flover/flover_be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flover/flover_be/global/exception/GlobalExceptionHandler.java
@@ -2,9 +2,12 @@ package com.flover.flover_be.global.exception;
 
 import com.flover.flover_be.global.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -16,6 +19,22 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParam(MissingServletRequestParameterException e) {
+        String message = "필수 파라미터가 누락되었습니다: " + e.getParameterName();
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), message));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        String message = "파라미터 형식이 올바르지 않습니다: " + e.getName();
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), message));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/flover/flover_be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flover/flover_be/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.flover.flover_be.global.exception;
 
 import com.flover.flover_be.global.response.ErrorResponse;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
         String message = "파라미터 형식이 올바르지 않습니다: " + e.getName();
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), message));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException e) {
+        String message = e.getConstraintViolations().stream()
+                .map(v -> v.getPropertyPath().toString().replaceAll(".*\\.", "") + ": " + v.getMessage())
+                .findFirst()
+                .orElse("요청 파라미터가 올바르지 않습니다.");
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), message));

--- a/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
+++ b/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
@@ -7,12 +7,15 @@ import com.flover.flover_be.plogging.service.PloggingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Plogging", description = "플로깅 API")
+@Validated
 @RestController
 @RequestMapping("/api/plogging-sessions")
 @RequiredArgsConstructor
@@ -51,8 +55,8 @@ public class PloggingController {
     @GetMapping("/monthly")
     public ResponseEntity<PloggingDto.MonthlyStatsResponse> getMonthlyStats(
             @LoginUserId Long userId,
-            @RequestParam int year,
-            @RequestParam int month
+            @RequestParam @Min(1) int year,
+            @RequestParam @Min(1) @Max(12) int month
     ) {
         return ResponseEntity.ok(ploggingService.findMonthlyStats(userId, year, month));
     }

--- a/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
+++ b/src/main/java/com/flover/flover_be/plogging/controller/PloggingController.java
@@ -7,11 +7,12 @@ import com.flover.flover_be.plogging.service.PloggingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,6 +45,25 @@ public class PloggingController {
             @PathVariable Long ploggingSessionId
     ) {
         return ResponseEntity.ok(ploggingService.findSession(userId, ploggingSessionId));
+    }
+
+    @Operation(summary = "월간 플로깅 통계 조회", description = "지정한 연월의 플로깅 누적 통계를 반환합니다.")
+    @GetMapping("/monthly")
+    public ResponseEntity<PloggingDto.MonthlyStatsResponse> getMonthlyStats(
+            @LoginUserId Long userId,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        return ResponseEntity.ok(ploggingService.findMonthlyStats(userId, year, month));
+    }
+
+    @Operation(summary = "주간 플로깅 통계 조회", description = "startDate 기준 7일간의 날짜별 플로깅 통계를 반환합니다.")
+    @GetMapping("/weekly")
+    public ResponseEntity<PloggingDto.WeeklyStatsResponse> getWeeklyStats(
+            @LoginUserId Long userId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate
+    ) {
+        return ResponseEntity.ok(ploggingService.findWeeklyStats(userId, startDate));
     }
 
     @Operation(summary = "플로깅 완료 기록 저장",

--- a/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
+++ b/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
@@ -9,6 +9,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -67,5 +69,31 @@ public class PloggingDto {
             int restSeconds,
             String mapImageUrl,
             List<String> photoUrls
+    ) {}
+
+    public record MonthlyStatsResponse(
+            int year,
+            int month,
+            long totalStepCount,
+            long totalDistanceMeters,
+            long totalCaloriesBurned,
+            long totalPloggingCount,
+            long totalPloggingSeconds
+    ) {}
+
+    public record WeeklyStatsResponse(
+            LocalDate startDate,
+            LocalDate endDate,
+            List<DailyStatsResponse> dailyStats
+    ) {}
+
+    public record DailyStatsResponse(
+            LocalDate date,
+            DayOfWeek dayOfWeek,
+            long stepCount,
+            long distanceMeters,
+            long caloriesBurned,
+            long ploggingCount,
+            long ploggingSeconds
     ) {}
 }

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PloggingSessionRepository extends JpaRepository<PloggingSession, Long> {
@@ -18,9 +20,20 @@ public interface PloggingSessionRepository extends JpaRepository<PloggingSession
     @Query("SELECT COUNT(p) AS count, COALESCE(SUM(p.stepCount), 0) AS totalStepCount, COALESCE(SUM(p.distanceMeters), 0) AS totalDistanceMeters FROM PloggingSession p WHERE p.user.id = :userId")
     PloggingStatsView findStatsByUserId(@Param("userId") Long userId);
 
+    @Query("SELECT p.finishedAt AS finishedAt, p.stepCount AS stepCount, p.distanceMeters AS distanceMeters, p.caloriesBurned AS caloriesBurned, p.ploggingSeconds AS ploggingSeconds FROM PloggingSession p WHERE p.user.id = :userId AND p.finishedAt >= :start AND p.finishedAt < :end")
+    List<SessionStatsView> findSessionStatsInPeriod(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
     interface PloggingStatsView {
         long getCount();
         long getTotalStepCount();
         long getTotalDistanceMeters();
+    }
+
+    interface SessionStatsView {
+        LocalDateTime getFinishedAt();
+        int getStepCount();
+        int getDistanceMeters();
+        int getCaloriesBurned();
+        int getPloggingSeconds();
     }
 }

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -112,14 +112,11 @@ public class PloggingService {
         LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0, 0);
         LocalDateTime end = start.plusMonths(1);
         List<PloggingSessionRepository.SessionStatsView> sessions = fetchPeriodStats(userId, start, end);
+        SessionAggregate agg = SessionAggregate.from(sessions);
         return new PloggingDto.MonthlyStatsResponse(
-                year,
-                month,
-                sessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getStepCount).sum(),
-                sessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getDistanceMeters).sum(),
-                sessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getCaloriesBurned).sum(),
-                sessions.size(),
-                sessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getPloggingSeconds).sum()
+                year, month,
+                agg.stepCount(), agg.distanceMeters(), agg.caloriesBurned(),
+                sessions.size(), agg.ploggingSeconds()
         );
     }
 
@@ -138,14 +135,11 @@ public class PloggingService {
                 .mapToObj(startDate::plusDays)
                 .map(date -> {
                     List<PloggingSessionRepository.SessionStatsView> daySessions = byDate.getOrDefault(date, List.of());
+                    SessionAggregate agg = SessionAggregate.from(daySessions);
                     return new PloggingDto.DailyStatsResponse(
-                            date,
-                            date.getDayOfWeek(),
-                            daySessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getStepCount).sum(),
-                            daySessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getDistanceMeters).sum(),
-                            daySessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getCaloriesBurned).sum(),
-                            daySessions.size(),
-                            daySessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getPloggingSeconds).sum()
+                            date, date.getDayOfWeek(),
+                            agg.stepCount(), agg.distanceMeters(), agg.caloriesBurned(),
+                            daySessions.size(), agg.ploggingSeconds()
                     );
                 })
                 .toList();
@@ -155,6 +149,19 @@ public class PloggingService {
 
     private List<PloggingSessionRepository.SessionStatsView> fetchPeriodStats(Long userId, LocalDateTime start, LocalDateTime end) {
         return ploggingSessionRepository.findSessionStatsInPeriod(userId, start, end);
+    }
+
+    private record SessionAggregate(long stepCount, long distanceMeters, long caloriesBurned, long ploggingSeconds) {
+        static SessionAggregate from(List<PloggingSessionRepository.SessionStatsView> sessions) {
+            long stepCount = 0, distanceMeters = 0, caloriesBurned = 0, ploggingSeconds = 0;
+            for (PloggingSessionRepository.SessionStatsView s : sessions) {
+                stepCount += s.getStepCount();
+                distanceMeters += s.getDistanceMeters();
+                caloriesBurned += s.getCaloriesBurned();
+                ploggingSeconds += s.getPloggingSeconds();
+            }
+            return new SessionAggregate(stepCount, distanceMeters, caloriesBurned, ploggingSeconds);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -20,8 +20,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -99,6 +104,57 @@ public class PloggingService {
                 session.getMapImageUrl(),
                 photoUrls
         );
+    }
+
+    @Transactional(readOnly = true)
+    public PloggingDto.MonthlyStatsResponse findMonthlyStats(Long userId, int year, int month) {
+        validateUserExists(userId);
+        LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0, 0);
+        LocalDateTime end = start.plusMonths(1);
+        List<PloggingSessionRepository.SessionStatsView> sessions = fetchPeriodStats(userId, start, end);
+        return new PloggingDto.MonthlyStatsResponse(
+                year,
+                month,
+                sessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getStepCount).sum(),
+                sessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getDistanceMeters).sum(),
+                sessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getCaloriesBurned).sum(),
+                sessions.size(),
+                sessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getPloggingSeconds).sum()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public PloggingDto.WeeklyStatsResponse findWeeklyStats(Long userId, LocalDate startDate) {
+        validateUserExists(userId);
+        LocalDate endDate = startDate.plusDays(6);
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = endDate.plusDays(1).atStartOfDay();
+        List<PloggingSessionRepository.SessionStatsView> sessions = fetchPeriodStats(userId, start, end);
+
+        Map<LocalDate, List<PloggingSessionRepository.SessionStatsView>> byDate = sessions.stream()
+                .collect(Collectors.groupingBy(s -> s.getFinishedAt().toLocalDate()));
+
+        List<PloggingDto.DailyStatsResponse> dailyStats = IntStream.range(0, 7)
+                .mapToObj(startDate::plusDays)
+                .map(date -> {
+                    List<PloggingSessionRepository.SessionStatsView> daySessions = byDate.getOrDefault(date, List.of());
+                    return new PloggingDto.DailyStatsResponse(
+                            date,
+                            date.getDayOfWeek(),
+                            daySessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getStepCount).sum(),
+                            daySessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getDistanceMeters).sum(),
+                            daySessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getCaloriesBurned).sum(),
+                            daySessions.size(),
+                            daySessions.stream().mapToLong(PloggingSessionRepository.SessionStatsView::getPloggingSeconds).sum()
+                    );
+                })
+                .toList();
+
+        return new PloggingDto.WeeklyStatsResponse(startDate, endDate, dailyStats);
+    }
+
+    private List<PloggingSessionRepository.SessionStatsView> fetchPeriodStats(Long userId, LocalDateTime start, LocalDateTime end) {
+        return ploggingSessionRepository.findSessionStatsInPeriod(userId, start, end);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
@@ -23,6 +23,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -369,6 +371,147 @@ class PloggingServiceTest {
         assertThat(result.photoUrls().get(0)).isEqualTo("https://s3.example.com/first.jpg");
         assertThat(result.photoUrls().get(1)).isEqualTo("https://s3.example.com/second.jpg");
         assertThat(result.photoUrls().get(2)).isEqualTo("https://s3.example.com/third.jpg");
+    }
+
+    @DisplayName("월간 통계를 정상적으로 집계해 반환한다")
+    @Test
+    void find_monthly_stats_성공() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        List<PloggingSessionRepository.SessionStatsView> sessions = List.of(
+                mockSessionStats(LocalDateTime.of(2026, 4, 10, 9, 0), 4000, 3000, 150, 1800),
+                mockSessionStats(LocalDateTime.of(2026, 4, 20, 9, 0), 5000, 4000, 200, 2400)
+        );
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.findSessionStatsInPeriod(
+                anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(sessions);
+
+        // when
+        PloggingDto.MonthlyStatsResponse result = ploggingService.findMonthlyStats(userId, 2026, 4);
+
+        // then
+        assertThat(result.year()).isEqualTo(2026);
+        assertThat(result.month()).isEqualTo(4);
+        assertThat(result.totalPloggingCount()).isEqualTo(2);
+        assertThat(result.totalStepCount()).isEqualTo(9000L);
+        assertThat(result.totalDistanceMeters()).isEqualTo(7000L);
+        assertThat(result.totalCaloriesBurned()).isEqualTo(350L);
+        assertThat(result.totalPloggingSeconds()).isEqualTo(4200L);
+    }
+
+    @DisplayName("플로깅 기록이 없는 달은 모든 통계가 0이다")
+    @Test
+    void find_monthly_stats_기록없음_모두_0() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.findSessionStatsInPeriod(
+                anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(List.of());
+
+        // when
+        PloggingDto.MonthlyStatsResponse result = ploggingService.findMonthlyStats(userId, 2026, 4);
+
+        // then
+        assertThat(result.totalPloggingCount()).isZero();
+        assertThat(result.totalStepCount()).isZero();
+        assertThat(result.totalDistanceMeters()).isZero();
+        assertThat(result.totalCaloriesBurned()).isZero();
+        assertThat(result.totalPloggingSeconds()).isZero();
+    }
+
+    @DisplayName("존재하지 않는 유저로 월간 통계 조회 시 예외가 발생한다")
+    @Test
+    void find_monthly_stats_유저없음_예외() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ploggingService.findMonthlyStats(1L, 2026, 4))
+                .isInstanceOf(UserException.class);
+    }
+
+    @DisplayName("주간 통계는 7개의 날짜 데이터를 반환한다")
+    @Test
+    void find_weekly_stats_7개_날짜_반환() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        LocalDate startDate = LocalDate.of(2026, 4, 14);
+        List<PloggingSessionRepository.SessionStatsView> sessions = List.of(
+                mockSessionStats(LocalDateTime.of(2026, 4, 15, 9, 0), 4800, 3900, 220, 3600)
+        );
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.findSessionStatsInPeriod(
+                anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(sessions);
+
+        // when
+        PloggingDto.WeeklyStatsResponse result = ploggingService.findWeeklyStats(userId, startDate);
+
+        // then
+        assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 4, 14));
+        assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 4, 20));
+        assertThat(result.dailyStats()).hasSize(7);
+        assertThat(result.dailyStats().get(0).dayOfWeek()).isEqualTo(DayOfWeek.TUESDAY);
+    }
+
+    @DisplayName("플로깅 기록이 없는 날은 0으로 채워진다")
+    @Test
+    void find_weekly_stats_기록없는_날_0으로_채워짐() {
+        // given
+        Long userId = 1L;
+        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        LocalDate startDate = LocalDate.of(2026, 4, 14);
+        List<PloggingSessionRepository.SessionStatsView> sessions = List.of(
+                mockSessionStats(LocalDateTime.of(2026, 4, 15, 9, 0), 4800, 3900, 220, 3600)
+        );
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.findSessionStatsInPeriod(
+                anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(sessions);
+
+        // when
+        PloggingDto.WeeklyStatsResponse result = ploggingService.findWeeklyStats(userId, startDate);
+
+        // then
+        PloggingDto.DailyStatsResponse monday = result.dailyStats().get(0);   // 4/14 월요일
+        PloggingDto.DailyStatsResponse tuesday = result.dailyStats().get(1);  // 4/15 화요일
+        assertThat(monday.stepCount()).isZero();
+        assertThat(monday.ploggingCount()).isZero();
+        assertThat(tuesday.stepCount()).isEqualTo(4800L);
+        assertThat(tuesday.ploggingCount()).isEqualTo(1L);
+        assertThat(tuesday.caloriesBurned()).isEqualTo(220L);
+    }
+
+    @DisplayName("존재하지 않는 유저로 주간 통계 조회 시 예외가 발생한다")
+    @Test
+    void find_weekly_stats_유저없음_예외() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ploggingService.findWeeklyStats(1L, LocalDate.of(2026, 4, 14)))
+                .isInstanceOf(UserException.class);
+    }
+
+    private PloggingSessionRepository.SessionStatsView mockSessionStats(
+            LocalDateTime finishedAt, int stepCount, int distanceMeters, int caloriesBurned, int ploggingSeconds
+    ) {
+        return new PloggingSessionRepository.SessionStatsView() {
+            public LocalDateTime getFinishedAt() { return finishedAt; }
+            public int getStepCount() { return stepCount; }
+            public int getDistanceMeters() { return distanceMeters; }
+            public int getCaloriesBurned() { return caloriesBurned; }
+            public int getPloggingSeconds() { return ploggingSeconds; }
+        };
     }
 
     private PloggingDto.CompleteRequest buildRequest(


### PR DESCRIPTION
## 관련 이슈
- close #23 

## 작업 내용
- `GET /api/plogging-sessions/monthly?year=2026&month=4` 월간 플로깅 누적 통계 조회 API 구현
- `GET /api/plogging-sessions/weekly?startDate=2026-04-14` 주간 플로깅 날짜별 통계 조회 API 구현
- `PloggingSessionRepository`에 `SessionStatsView` 인터페이스 프로젝션과 `findSessionStatsInPeriod` 추가
  - `finishedAt` 기준으로 기간 내 세션의 필요 필드만 조회
  - 월간/주간 통계 조회에서 `fetchPeriodStats(userId, start, end)`를 통해 공통 재사용
- 월간 통계 조회 로직 구현
  - 기간 내 세션의 걸음 수, 거리, 칼로리, 플로깅 시간, 세션 수를 집계하여 반환
- 주간 통계 조회 로직 구현
  - 기간 내 세션을 날짜별로 그룹핑
  - `startDate` 기준 7일을 순회하며 날짜별 통계 반환
  - 기록이 없는 날은 0으로 채워 반환
- `GlobalExceptionHandler`에 400 Bad Request 처리 추가
  - `MissingServletRequestParameterException`: 필수 파라미터 누락 시 400 응답
  - `MethodArgumentTypeMismatchException`: 타입 변환 실패 시 400 응답

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.
  - 월간 통계 정상 집계 반환
  - 플로깅 기록이 없는 달은 모든 값 0 반환
  - 주간 통계 7개 날짜 항목 반환
  - 기록 없는 날은 0으로 채워지는 것 확인
  - 존재하지 않는 유저 조회 시 예외 발생 확인
    - 월간 통계
    - 주간 통계

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.

## 참고
###<img width="509" height="1021" alt="image" src="https://github.com/user-attachments/assets/9a61037b-e727-4951-9e4e-26873dc75027" />
검정 동그라미 친 월간 통계 부분에서 수거한 쓰레기는 반환하지 않습니다. 기획에서 "줍" 기능이 제거되었기에 반환하지 않습니다. 이에 따라 DE에게 피그마 수정을 요청한 상태입니다.

### 파라미터를 프론트가 잘못 입력할 경우 빠르게 원인을 파악하는데 돕도록 다음과 같이 에러 응답을 반환합니다
<img width="568" height="167" alt="image" src="https://github.com/user-attachments/assets/cfd346e5-4698-45e1-b4b4-7f1d67f58df5" />

### 월간 플로깅 통계 조회
<img width="368" height="226" alt="image" src="https://github.com/user-attachments/assets/2dfc1331-0f3f-4ac6-b861-2c187adb66ea" />

### 주간 플로깅 통계 조회
<img width="460" height="1319" alt="image" src="https://github.com/user-attachments/assets/452e4d78-7a0f-409c-91dd-e3744ed8ddbb" />


