### PR TITLE
[fix]: CORS credentials 설정 정리 및 허용 메서드 명시

### DIFF
--- a/src/main/java/com/flover/flover_be/global/config/WebConfig.java
+++ b/src/main/java/com/flover/flover_be/global/config/WebConfig.java
@@ -21,9 +21,10 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
                 .allowedOrigins("http://localhost:3000")
-                .allowedMethods("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
-                .allowCredentials(true);
+                .allowCredentials(false)
+                .maxAge(3600);
     }
 
     @Override


### PR DESCRIPTION
## 관련 이슈
- close #27 

## 작업 내용
- CORS 설정에서 `allowCredentials(true)`를 `allowCredentials(false)`로 수정했습니다.
- `allowedMethods("*")` 대신 실제 허용할 HTTP 메서드(`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`)를 명시했습니다.
- preflight 요청 캐싱을 위해 `maxAge(3600)` 설정을 추가했습니다.

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.