### PR TITLE
[refactor]: 유저 정보 조회 엔드포인트를 /{userId}에서 /me로 변경

### DIFF
--- a/src/main/java/com/flover/flover_be/user/controller/UserController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/UserController.java
@@ -7,11 +7,9 @@ import com.flover.flover_be.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,9 +24,9 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "유저 정보 조회", description = "닉네임, 레벨, 프로필 이미지 URL 반환")
-    @GetMapping("/{userId}")
-    public ResponseEntity<UserDto.UserInfoResponse> getUserInfo(@PathVariable @Positive Long userId) {
+    @Operation(summary = "내 정보 조회", description = "닉네임, 레벨, 프로필 이미지 URL 반환")
+    @GetMapping("/me")
+    public ResponseEntity<UserDto.UserInfoResponse> getMyInfo(@LoginUserId Long userId) {
         return ResponseEntity.ok(userService.findUserInfo(userId));
     }
 

--- a/src/main/java/com/flover/flover_be/user/controller/UserController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/UserController.java
@@ -24,7 +24,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "내 정보 조회", description = "닉네임, 레벨, 프로필 이미지 URL 반환")
+    @Operation(summary = "내 정보 조회", description = "닉네임, 레벨, 칭호, 프로필 이미지 URL 반환")
     @GetMapping("/me")
     public ResponseEntity<UserDto.UserInfoResponse> getMyInfo(@LoginUserId Long userId) {
         return ResponseEntity.ok(userService.findUserInfo(userId));


### PR DESCRIPTION
## 관련 이슈
- close #29 

## 작업 내용
- `GET /api/users/{userId}` → `GET /api/users/me`로 엔드포인트 변경
- `userId` 경로 변수 제거
- JWT 토큰 기반 `@LoginUserId`를 사용해 로그인한 사용자 본인 식별
- 불필요한 `@PathVariable`, `@Positive` import 제거

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.
  - JWT 인증 후 `GET /api/users/me` 요청 시 본인 정보가 정상 조회되는지 확인
  - 기존 사용자 정보 조회 로직이 정상 동작하는지 확인

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.