### PR TITLE
[chore]: Docker 및 GitHub Actions 배포 자동화 설정 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+.gradle
+build
+.env
+*.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy to EC2
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: EC2 배포
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+          KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
+          KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          envs: DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,JWT_SECRET,JWT_EXPIRATION,AWS_REGION,AWS_S3_BUCKET,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY
+          script: |
+            cd ~/flover-be
+            git pull origin main
+
+            cat > .env <<EOF
+            DB_URL=jdbc:mysql://mysql:3306/flover_db
+            DB_USERNAME=${DB_USERNAME}
+            DB_PASSWORD=${DB_PASSWORD}
+            KAKAO_CLIENT_ID=${KAKAO_CLIENT_ID}
+            KAKAO_CLIENT_SECRET=${KAKAO_CLIENT_SECRET}
+            KAKAO_REDIRECT_URI=${KAKAO_REDIRECT_URI}
+            JWT_SECRET=${JWT_SECRET}
+            JWT_EXPIRATION=${JWT_EXPIRATION}
+            AWS_REGION=${AWS_REGION}
+            AWS_S3_BUCKET=${AWS_S3_BUCKET}
+            AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+            AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+            EOF
+
+            docker compose up -d --build
+
+            docker image prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# ── Stage 1: 빌드 ──────────────────────────────────────────────
+# gradle + JDK 21 이미지로 jar 파일 생성
+FROM gradle:8-jdk21 AS builder
+
+WORKDIR /app
+
+# 의존성 캐시 레이어 분리 (소스 변경 시 의존성 재다운로드 방지)
+COPY build.gradle settings.gradle ./
+RUN gradle dependencies --no-daemon || true
+
+COPY src ./src
+RUN gradle bootJar --no-daemon -x test
+
+# ── Stage 2: 실행 ──────────────────────────────────────────────
+# JRE만 있는 가벼운 이미지로 jar 실행 (빌드 도구 제외)
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  mysql:
+    image: mysql:8
+    container_name: flover-mysql
+    environment:
+      MYSQL_DATABASE: flover_db
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - mysql-data:/var/lib/mysql
+    restart: unless-stopped
+
+  app:
+    build: .
+    container_name: flover-be
+    env_file: .env
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql
+    restart: unless-stopped
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
## 관련 이슈
- close #31 

## 작업 내용
- `Dockerfile` 추가
  - 빌드 스테이지에서 `gradle:8-jdk21` 이미지로 `bootJar` 실행
  - 실행 스테이지에서 `eclipse-temurin:21-jre` 이미지로 빌드된 jar만 실행
  - 최종 이미지에서 Gradle 등 빌드 도구를 제외하여 이미지 경량화
  - `build.gradle`, `settings.gradle`을 먼저 복사해 의존성 캐시 레이어 분리
- `docker-compose.yml` 추가
  - `mysql:8` 컨테이너로 별도 DB 서버 없이 EC2 내부에서 MySQL 운영
  - `mysql-data` volume을 사용해 컨테이너 재시작 후에도 DB 데이터 유지
  - Spring Boot 앱 컨테이너와 MySQL 컨테이너를 함께 관리
  - `depends_on`으로 MySQL 컨테이너 실행 후 앱 컨테이너가 시작되도록 구성
- `.github/workflows/deploy.yml` 추가
  - `main` 브랜치 push 시 자동 배포 트리거
  - `appleboy/ssh-action`을 사용해 EC2에 SSH 접속
  - GitHub Secrets 값을 기반으로 EC2에 `.env` 파일 생성
  - `docker compose up -d --build`로 이미지 빌드 및 컨테이너 교체 자동화
  - 배포 후 `docker image prune -f`로 미사용 이미지 정리
- `.dockerignore` 추가
  - `.git`, `build`, `.gradle`, `.env` 등 Docker 빌드에 불필요하거나 민감한 파일을 빌드 컨텍스트에서 제외

## 테스트
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.
  - 기존 애플리케이션 테스트 통과 확인

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.