### PR TITLE
[fix]: Docker 및 CI/CD 설정 오류 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # 의존성 캐시 레이어 분리 (소스 변경 시 의존성 재다운로드 방지)
 COPY build.gradle settings.gradle ./
-RUN gradle dependencies --no-daemon || true
+RUN gradle dependencies --no-daemon
 
 COPY src ./src
 RUN gradle bootJar --no-daemon -x test

--- a/build.gradle
+++ b/build.gradle
@@ -38,3 +38,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+jar {
+	enabled = false
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DB_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   app:
     build: .
@@ -18,7 +23,8 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - mysql-data:/var/lib/mysql
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DB_PASSWORD}"]
+      test: ["CMD-SHELL", "MYSQL_PWD=\"${DB_PASSWORD}\" mysqladmin ping -h localhost -u root"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## 관련 이슈
- close #33

## 작업 내용
- `build.gradle`에서 plain jar 생성 비활성화
  - `jar { enabled = false }` 추가
  - Spring Boot 실행용 `bootJar`만 생성되도록 수정
- `Dockerfile` 의존성 캐싱 단계에서 `|| true` 제거
  - 의존성 다운로드 실패 시 오류를 무시하지 않고 빌드가 실패하도록 수정
- `docker-compose.yml`에 MySQL healthcheck 추가
  - MySQL 컨테이너가 실제로 준비되었는지 확인
  - 앱 컨테이너는 `condition: service_healthy` 조건을 통해 MySQL 준비 완료 후 실행되도록 수정

## 테스트
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.
  - 기존 애플리케이션 테스트 통과 확인

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.