### PR TITLE
[chore]: 배포 워크플로우 브랜치 develop으로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 
 on:
   push:
-    branches: [ main ]
+    branches: [ develop ]
 
 jobs:
   deploy:


### PR DESCRIPTION
## 관련 이슈
- close #35 

## 작업 내용
- GitHub Actions 배포 워크플로우 트리거 브랜치를 `main`에서 `develop`으로 변경