### PR TITLE
[fix]: EC2 배포 시 git pull 대상 브랜치 main → develop으로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           envs: DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,JWT_SECRET,JWT_EXPIRATION,AWS_REGION,AWS_S3_BUCKET,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY
           script: |
             cd ~/flover-be
-            git pull origin main
+            git pull origin develop
 
             cat > .env <<EOF
             DB_URL=jdbc:mysql://mysql:3306/flover_db


### PR DESCRIPTION
## 관련 이슈
- close #35 

## 작업 내용
- EC2에서 최신 코드를 가져오는 브랜치를 `main`에서 `develop`으로 변경하는 코드가 빠진채로 머지되어서 다시 pr 날립니다.