### PR TITLE
[refactor]: GitHub Actions에서 이미지 빌드 후 Docker Hub push, EC2는 pull만 하도록…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,28 @@ on:
     branches: [ develop ]
 
 jobs:
-  deploy:
+  build-and-push:
     runs-on: ubuntu-latest
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
 
+      - name: Docker Hub 로그인
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Docker 이미지 빌드 및 Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/flover-be:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
     steps:
       - name: EC2 배포
         uses: appleboy/ssh-action@v1.0.3
@@ -23,11 +42,12 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          APP_IMAGE: ${{ secrets.DOCKER_HUB_USERNAME }}/flover-be:latest
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,JWT_SECRET,JWT_EXPIRATION,AWS_REGION,AWS_S3_BUCKET,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY
+          envs: DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,JWT_SECRET,JWT_EXPIRATION,AWS_REGION,AWS_S3_BUCKET,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,APP_IMAGE
           script: |
             cd ~/flover-be
             git pull origin develop
@@ -45,8 +65,9 @@ jobs:
             AWS_S3_BUCKET=${AWS_S3_BUCKET}
             AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
             AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+            APP_IMAGE=${APP_IMAGE}
             EOF
 
-            docker compose up -d --build
-
+            docker compose pull app
+            docker compose up -d
             docker image prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   app:
-    build: .
+    image: ${APP_IMAGE}
     container_name: flover-be
     env_file: .env
     ports:


### PR DESCRIPTION
## 관련 이슈
- close #38 

## 작업 내용
- `deploy.yml` 워크플로우를 `build-and-push` / `deploy` 두 job으로 분리했습니다.
  - `build-and-push`: GitHub Actions runner에서 Docker 이미지를 빌드한 뒤 Docker Hub에 push합니다.
  - `deploy`: EC2에서 `docker compose pull` 후 `docker compose up -d`만 실행하도록 변경했습니다.
- `docker-compose.yml`의 app 서비스를 `build: .` 기반에서 `image: ${APP_IMAGE}` 기반으로 변경했습니다.
- 배포 시 생성되는 `.env`에 `APP_IMAGE`를 추가하여 Docker Hub 이미지 경로를 주입하도록 했습니다.

## 테스트
- [ ] 로컬에서 정상 동작을 확인했습니다.
- [ ] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.
- [x] GitHub Actions workflow 문법과 Secret 참조명을 확인했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.