### PR TITLE
[feat]: 주변 쓰레기통/화장실 위치 조회 API 구현

### DIFF
--- a/src/main/java/com/flover/flover_be/facility/controller/FacilityController.java
+++ b/src/main/java/com/flover/flover_be/facility/controller/FacilityController.java
@@ -1,0 +1,45 @@
+package com.flover.flover_be.facility.controller;
+
+import com.flover.flover_be.facility.dto.FacilityDto;
+import com.flover.flover_be.facility.service.FacilityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Facility", description = "주변 시설 API")
+@Validated
+@RestController
+@RequestMapping("/api/facilities")
+@RequiredArgsConstructor
+public class FacilityController {
+
+    private final FacilityService facilityService;
+
+    @Operation(summary = "주변 쓰레기통 조회", description = "현재 위치 기준 반경 1000m 이내 쓰레기통을 가까운 순으로 반환합니다.")
+    @GetMapping("/trash-bins")
+    public ResponseEntity<List<FacilityDto.TrashBinResponse>> getNearbyTrashBins(
+            @RequestParam @DecimalMin("-90.0") @DecimalMax("90.0") double lat,
+            @RequestParam @DecimalMin("-180.0") @DecimalMax("180.0") double lng
+    ) {
+        return ResponseEntity.ok(facilityService.findNearbyTrashBins(lat, lng));
+    }
+
+    @Operation(summary = "주변 화장실 조회", description = "현재 위치 기준 반경 1000m 이내 화장실을 가까운 순으로 반환합니다.")
+    @GetMapping("/toilets")
+    public ResponseEntity<List<FacilityDto.ToiletResponse>> getNearbyToilets(
+            @RequestParam @DecimalMin("-90.0") @DecimalMax("90.0") double lat,
+            @RequestParam @DecimalMin("-180.0") @DecimalMax("180.0") double lng
+    ) {
+        return ResponseEntity.ok(facilityService.findNearbyToilets(lat, lng));
+    }
+}

--- a/src/main/java/com/flover/flover_be/facility/domain/Toilet.java
+++ b/src/main/java/com/flover/flover_be/facility/domain/Toilet.java
@@ -1,0 +1,45 @@
+package com.flover.flover_be.facility.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "toilets")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Toilet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "road_address")
+    private String roadAddress;
+
+    @Column(nullable = false)
+    private double latitude;
+
+    @Column(nullable = false)
+    private double longitude;
+
+    @Column(name = "toilet_type")
+    private String toiletType;
+
+    @Column(name = "open_time_type")
+    private String openTimeType;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/flover/flover_be/facility/domain/TrashBin.java
+++ b/src/main/java/com/flover/flover_be/facility/domain/TrashBin.java
@@ -1,0 +1,42 @@
+package com.flover.flover_be.facility.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "trash_bins")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrashBin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "road_address")
+    private String roadAddress;
+
+    @Column(nullable = false)
+    private double latitude;
+
+    @Column(nullable = false)
+    private double longitude;
+
+    @Column(name = "trash_type")
+    private String trashType;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/flover/flover_be/facility/dto/FacilityDto.java
+++ b/src/main/java/com/flover/flover_be/facility/dto/FacilityDto.java
@@ -1,0 +1,25 @@
+package com.flover.flover_be.facility.dto;
+
+public class FacilityDto {
+
+    public record TrashBinResponse(
+            Long id,
+            String name,
+            String roadAddress,
+            double latitude,
+            double longitude,
+            String trashType,
+            long distanceMeters
+    ) {}
+
+    public record ToiletResponse(
+            Long id,
+            String name,
+            String roadAddress,
+            double latitude,
+            double longitude,
+            String toiletType,
+            String openTimeType,
+            long distanceMeters
+    ) {}
+}

--- a/src/main/java/com/flover/flover_be/facility/repository/ToiletRepository.java
+++ b/src/main/java/com/flover/flover_be/facility/repository/ToiletRepository.java
@@ -1,0 +1,32 @@
+package com.flover.flover_be.facility.repository;
+
+import com.flover.flover_be.facility.domain.Toilet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ToiletRepository extends JpaRepository<Toilet, Long> {
+
+    @Query(value = """
+            SELECT id, name, road_address AS roadAddress, latitude, longitude,
+                   toilet_type AS toiletType, open_time_type AS openTimeType,
+                   ST_Distance_Sphere(POINT(longitude, latitude), POINT(:lng, :lat)) AS distanceMeters
+            FROM toilets
+            WHERE ST_Distance_Sphere(POINT(longitude, latitude), POINT(:lng, :lat)) <= :radius
+            ORDER BY distanceMeters ASC
+            """, nativeQuery = true)
+    List<ToiletView> findNearby(@Param("lat") double lat, @Param("lng") double lng, @Param("radius") int radius);
+
+    interface ToiletView {
+        Long getId();
+        String getName();
+        String getRoadAddress();
+        double getLatitude();
+        double getLongitude();
+        String getToiletType();
+        String getOpenTimeType();
+        double getDistanceMeters();
+    }
+}

--- a/src/main/java/com/flover/flover_be/facility/repository/TrashBinRepository.java
+++ b/src/main/java/com/flover/flover_be/facility/repository/TrashBinRepository.java
@@ -1,0 +1,30 @@
+package com.flover.flover_be.facility.repository;
+
+import com.flover.flover_be.facility.domain.TrashBin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface TrashBinRepository extends JpaRepository<TrashBin, Long> {
+
+    @Query(value = """
+            SELECT id, name, road_address AS roadAddress, latitude, longitude, trash_type AS trashType,
+                   ST_Distance_Sphere(POINT(longitude, latitude), POINT(:lng, :lat)) AS distanceMeters
+            FROM trash_bins
+            WHERE ST_Distance_Sphere(POINT(longitude, latitude), POINT(:lng, :lat)) <= :radius
+            ORDER BY distanceMeters ASC
+            """, nativeQuery = true)
+    List<TrashBinView> findNearby(@Param("lat") double lat, @Param("lng") double lng, @Param("radius") int radius);
+
+    interface TrashBinView {
+        Long getId();
+        String getName();
+        String getRoadAddress();
+        double getLatitude();
+        double getLongitude();
+        String getTrashType();
+        double getDistanceMeters();
+    }
+}

--- a/src/main/java/com/flover/flover_be/facility/service/FacilityService.java
+++ b/src/main/java/com/flover/flover_be/facility/service/FacilityService.java
@@ -1,0 +1,41 @@
+package com.flover.flover_be.facility.service;
+
+import com.flover.flover_be.facility.dto.FacilityDto;
+import com.flover.flover_be.facility.repository.ToiletRepository;
+import com.flover.flover_be.facility.repository.TrashBinRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FacilityService {
+
+    private static final int DEFAULT_SEARCH_RADIUS_METERS = 1000;
+
+    private final TrashBinRepository trashBinRepository;
+    private final ToiletRepository toiletRepository;
+
+    public List<FacilityDto.TrashBinResponse> findNearbyTrashBins(double lat, double lng) {
+        return trashBinRepository.findNearby(lat, lng, DEFAULT_SEARCH_RADIUS_METERS).stream()
+                .map(v -> new FacilityDto.TrashBinResponse(
+                        v.getId(), v.getName(), v.getRoadAddress(),
+                        v.getLatitude(), v.getLongitude(), v.getTrashType(),
+                        Math.round(v.getDistanceMeters())
+                ))
+                .toList();
+    }
+
+    public List<FacilityDto.ToiletResponse> findNearbyToilets(double lat, double lng) {
+        return toiletRepository.findNearby(lat, lng, DEFAULT_SEARCH_RADIUS_METERS).stream()
+                .map(v -> new FacilityDto.ToiletResponse(
+                        v.getId(), v.getName(), v.getRoadAddress(),
+                        v.getLatitude(), v.getLongitude(), v.getToiletType(), v.getOpenTimeType(),
+                        Math.round(v.getDistanceMeters())
+                ))
+                .toList();
+    }
+}

--- a/src/test/java/com/flover/flover_be/facility/service/FacilityServiceTest.java
+++ b/src/test/java/com/flover/flover_be/facility/service/FacilityServiceTest.java
@@ -1,0 +1,141 @@
+package com.flover.flover_be.facility.service;
+
+import com.flover.flover_be.facility.dto.FacilityDto;
+import com.flover.flover_be.facility.repository.ToiletRepository;
+import com.flover.flover_be.facility.repository.TrashBinRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class FacilityServiceTest {
+
+    @Mock private TrashBinRepository trashBinRepository;
+    @Mock private ToiletRepository toiletRepository;
+    @InjectMocks private FacilityService facilityService;
+
+    private static final double LAT = 35.1496;
+    private static final double LNG = 126.9219;
+    private static final int RADIUS = 1000;
+
+    @DisplayName("주변 쓰레기통을 정상적으로 조회한다")
+    @Test
+    void find_nearby_trash_bins_성공() {
+        // given
+        TrashBinRepository.TrashBinView view = mock(TrashBinRepository.TrashBinView.class);
+        given(view.getId()).willReturn(1L);
+        given(view.getName()).willReturn("광주 쓰레기통");
+        given(view.getRoadAddress()).willReturn("광주 동구 금남로 1");
+        given(view.getLatitude()).willReturn(35.1496);
+        given(view.getLongitude()).willReturn(126.9219);
+        given(view.getTrashType()).willReturn("일반");
+        given(view.getDistanceMeters()).willReturn(150.7);
+
+        given(trashBinRepository.findNearby(LAT, LNG, RADIUS)).willReturn(List.of(view));
+
+        // when
+        List<FacilityDto.TrashBinResponse> result = facilityService.findNearbyTrashBins(LAT, LNG);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).id()).isEqualTo(1L);
+        assertThat(result.get(0).name()).isEqualTo("광주 쓰레기통");
+        assertThat(result.get(0).trashType()).isEqualTo("일반");
+        assertThat(result.get(0).distanceMeters()).isEqualTo(151L);
+    }
+
+    @DisplayName("주변 쓰레기통이 없으면 빈 리스트를 반환한다")
+    @Test
+    void find_nearby_trash_bins_빈결과() {
+        // given
+        given(trashBinRepository.findNearby(LAT, LNG, RADIUS)).willReturn(List.of());
+
+        // when
+        List<FacilityDto.TrashBinResponse> result = facilityService.findNearbyTrashBins(LAT, LNG);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @DisplayName("distanceMeters는 반올림하여 long으로 반환한다")
+    @Test
+    void find_nearby_trash_bins_거리_반올림() {
+        // given
+        TrashBinRepository.TrashBinView view1 = mock(TrashBinRepository.TrashBinView.class);
+        given(view1.getId()).willReturn(1L);
+        given(view1.getName()).willReturn("A");
+        given(view1.getRoadAddress()).willReturn(null);
+        given(view1.getLatitude()).willReturn(35.1);
+        given(view1.getLongitude()).willReturn(126.9);
+        given(view1.getTrashType()).willReturn(null);
+        given(view1.getDistanceMeters()).willReturn(100.4);
+
+        TrashBinRepository.TrashBinView view2 = mock(TrashBinRepository.TrashBinView.class);
+        given(view2.getId()).willReturn(2L);
+        given(view2.getName()).willReturn("B");
+        given(view2.getRoadAddress()).willReturn(null);
+        given(view2.getLatitude()).willReturn(35.1);
+        given(view2.getLongitude()).willReturn(126.9);
+        given(view2.getTrashType()).willReturn(null);
+        given(view2.getDistanceMeters()).willReturn(200.5);
+
+        given(trashBinRepository.findNearby(LAT, LNG, RADIUS)).willReturn(List.of(view1, view2));
+
+        // when
+        List<FacilityDto.TrashBinResponse> result = facilityService.findNearbyTrashBins(LAT, LNG);
+
+        // then
+        assertThat(result.get(0).distanceMeters()).isEqualTo(100L);
+        assertThat(result.get(1).distanceMeters()).isEqualTo(201L);
+    }
+
+    @DisplayName("주변 화장실을 정상적으로 조회한다")
+    @Test
+    void find_nearby_toilets_성공() {
+        // given
+        ToiletRepository.ToiletView view = mock(ToiletRepository.ToiletView.class);
+        given(view.getId()).willReturn(1L);
+        given(view.getName()).willReturn("광주역 화장실");
+        given(view.getRoadAddress()).willReturn("광주 북구 경열로 1");
+        given(view.getLatitude()).willReturn(35.1496);
+        given(view.getLongitude()).willReturn(126.9219);
+        given(view.getToiletType()).willReturn("공중화장실");
+        given(view.getOpenTimeType()).willReturn("24시간");
+        given(view.getDistanceMeters()).willReturn(300.2);
+
+        given(toiletRepository.findNearby(LAT, LNG, RADIUS)).willReturn(List.of(view));
+
+        // when
+        List<FacilityDto.ToiletResponse> result = facilityService.findNearbyToilets(LAT, LNG);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).id()).isEqualTo(1L);
+        assertThat(result.get(0).name()).isEqualTo("광주역 화장실");
+        assertThat(result.get(0).toiletType()).isEqualTo("공중화장실");
+        assertThat(result.get(0).openTimeType()).isEqualTo("24시간");
+        assertThat(result.get(0).distanceMeters()).isEqualTo(300L);
+    }
+
+    @DisplayName("주변 화장실이 없으면 빈 리스트를 반환한다")
+    @Test
+    void find_nearby_toilets_빈결과() {
+        // given
+        given(toiletRepository.findNearby(LAT, LNG, RADIUS)).willReturn(List.of());
+
+        // when
+        List<FacilityDto.ToiletResponse> result = facilityService.findNearbyToilets(LAT, LNG);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #25
- close #26

## 작업 내용

### 시설 도메인 분리
- `facility` 도메인을 추가했습니다.
  - 플로깅 기능과 시설 조회 기능의 책임을 분리했습니다.

### 시설 엔티티 및 Repository 추가
- `TrashBin`, `Toilet` 엔티티를 추가했습니다.
  - 기존 DB의 쓰레기통, 화장실 테이블과 매핑했습니다.
- `TrashBinRepository`, `ToiletRepository`를 추가했습니다.
  - 사용자 위치 기준 1km 이내 시설을 조회합니다.
  - 거리 정보(`distanceMeters`)를 함께 반환합니다.
  - MySQL 좌표 순서 `POINT(longitude, latitude)`를 준수했습니다.

### 시설 조회 로직 구현
- `FacilityService`를 추가했습니다.
  - 시설 검색 반경은 1000m로 고정했습니다.
  - `distanceMeters`는 `Math.round()`로 반올림해 `long` 타입으로 반환합니다.

### API 및 검증 처리
- `FacilityController`를 추가했습니다.
  - 쓰레기통 조회 API: `GET /api/facilities/trash-bins`
  - 화장실 조회 API: `GET /api/facilities/toilets`
  - `@Validated`, `@DecimalMin`, `@DecimalMax`로 위도와 경도 범위를 검증합니다.
  - 위도는 `-90 ~ 90`, 경도는 `-180 ~ 180` 범위만 허용합니다.
  - 인증 없이 호출 가능한 공개 API로 구성했습니다.

### 테스트 추가
- `FacilityServiceTest`를 추가했습니다.
  - 시설 조회 로직에 대한 단위 테스트 5개를 작성했습니다.

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.