### PR TITLE
[feat]: 내 정보 조회 API 응답에 경험치(experience) 필드 추가

### DIFF
--- a/src/main/java/com/flover/flover_be/user/dto/UserDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/UserDto.java
@@ -12,7 +12,7 @@ public class UserDto {
 
     public record ProfileImageUrlRequest(@NotBlank String imageUrl) {}
 
-    public record UserInfoResponse(String nickname, int level, String title, String profileImageUrl) {}
+    public record UserInfoResponse(String nickname, int level, String title, String profileImageUrl, long experience) {}
 
     public record PloggingStatsResponse(
             long totalPloggingCount,

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -22,7 +22,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserDto.UserInfoResponse findUserInfo(Long userId) {
         User user = getUserOrThrow(userId);
-        return new UserDto.UserInfoResponse(user.getNickname(), user.getLevel(), user.getTitle().getDisplayName(), user.getProfileImageUrl());
+        return new UserDto.UserInfoResponse(user.getNickname(), user.getLevel(), user.getTitle().getDisplayName(), user.getProfileImageUrl(), user.getExperience());
     }
 
     @Transactional

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -51,6 +51,7 @@ class UserServiceTest {
         assertThat(result.level()).isEqualTo(1);
         assertThat(result.title()).isEqualTo("쓰봉이");
         assertThat(result.profileImageUrl()).isEqualTo("https://img.url/profile.png");
+        assertThat(result.experience()).isEqualTo(0L);
     }
 
     @DisplayName("존재하지 않는 유저 정보 조회 시 예외가 발생한다")


### PR DESCRIPTION
## 관련 이슈
- close #41  (이슈 번호)

## 작업 내용
- /api/users/me 응답 데이터에 유저 경험치 필드를 추가했습니다.

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.
