### PR TITLE
[chore]: 배포 전 필수 환경변수 검증 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,49 @@ on:
   workflow_dispatch:
 
 jobs:
+  validate-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 필수 환경변수 검증
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+          KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
+          KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AI_SERVER_URL: ${{ secrets.AI_SERVER_URL }}
+          AI_API_KEY: ${{ secrets.AI_API_KEY }}
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+          EC2_USER: ${{ secrets.EC2_USER }}
+          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+        run: |
+          MISSING=()
+          for VAR in DOCKER_HUB_USERNAME DOCKER_HUB_TOKEN DB_USERNAME DB_PASSWORD \
+                     KAKAO_CLIENT_ID KAKAO_CLIENT_SECRET KAKAO_REDIRECT_URI \
+                     JWT_SECRET JWT_EXPIRATION \
+                     AWS_REGION AWS_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY \
+                     AI_SERVER_URL AI_API_KEY \
+                     EC2_HOST EC2_USER EC2_SSH_KEY; do
+            if [ -z "${!VAR}" ]; then
+              MISSING+=("$VAR")
+            fi
+          done
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "❌ 누락된 secrets: ${MISSING[*]}"
+            exit 1
+          fi
+          echo "✅ 모든 환경변수 확인 완료"
+
   build-and-push:
+    needs: validate-secrets
     runs-on: ubuntu-latest
     steps:
       - name: 코드 체크아웃
@@ -26,7 +68,7 @@ jobs:
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/flover-be:latest
 
   deploy:
-    needs: build-and-push
+    needs: [validate-secrets, build-and-push]
     runs-on: ubuntu-latest
     steps:
       - name: EC2 배포

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,12 +43,14 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AI_SERVER_URL: ${{ secrets.AI_SERVER_URL }}
+          AI_API_KEY: ${{ secrets.AI_API_KEY }}
           APP_IMAGE: ${{ secrets.DOCKER_HUB_USERNAME }}/flover-be:latest
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,JWT_SECRET,JWT_EXPIRATION,AWS_REGION,AWS_S3_BUCKET,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,APP_IMAGE
+          envs: DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,JWT_SECRET,JWT_EXPIRATION,AWS_REGION,AWS_S3_BUCKET,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AI_SERVER_URL,AI_API_KEY,APP_IMAGE
           script: |
             cd ~/flover-be
             git pull origin develop
@@ -66,6 +68,8 @@ jobs:
             AWS_S3_BUCKET=${AWS_S3_BUCKET}
             AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
             AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+            AI_SERVER_URL=${AI_SERVER_URL}
+            AI_API_KEY=${AI_API_KEY}
             APP_IMAGE=${APP_IMAGE}
             EOF
 


### PR DESCRIPTION
## 관련 이슈
- close #44 

## 작업 내용
- `AI_SERVER_URL`, `AI_API_KEY` 환경변수가 `deploy` job에 전달되지 않던 문제를 수정했습니다.
  - GitHub Secrets에는 값이 등록되어 있었지만, `envs` 및 `.env` 생성 단계에 포함되지 않아 EC2 컨테이너 실행 시 환경변수가 주입되지 않는 문제가 있었습니다.
- `validate-secrets` job을 추가했습니다.
  - 배포 파이프라인 시작 전에 필수 환경변수 18개를 검증합니다.
  - 누락된 환경변수가 있을 경우 해당 변수명을 출력하고 워크플로우 전체를 즉시 중단하도록 했습니다.
- `build-and-push`, `deploy` job이 `validate-secrets` 통과 후에만 실행되도록 의존성을 설정했습니다.

## 테스트
- [x] GitHub Actions에서 `validate-secrets` job이 정상 실행되는 것을 확인했습니다.
- [x] 필수 Secrets가 모두 존재할 때 빌드 및 배포가 정상 진행되는 것을 확인했습니다.
- [x] 배포 후 서버가 정상 실행되고 Swagger 접속이 가능한 것을 확인했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.
