### PR TITLE
feat: Route Engine 연동 모듈 추가 (RestClient + Retry)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'software.amazon.awssdk:s3:2.25.70'

--- a/src/main/java/com/flover/flover_be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flover/flover_be/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -21,6 +22,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode.getStatus().value(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .findFirst()
+                .orElse("요청 파라미터가 올바르지 않습니다.");
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), message));
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)

--- a/src/main/java/com/flover/flover_be/route/client/RouteEngineClient.java
+++ b/src/main/java/com/flover/flover_be/route/client/RouteEngineClient.java
@@ -1,0 +1,68 @@
+package com.flover.flover_be.route.client;
+
+import com.flover.flover_be.route.dto.RouteDto;
+import com.flover.flover_be.route.exception.RouteErrorCode;
+import com.flover.flover_be.route.exception.RouteException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+public class RouteEngineClient {
+
+    private final RestClient restClient;
+
+    public RouteEngineClient(
+            @Value("${route.engine.url}") String routeEngineUrl,
+            RestClient.Builder restClientBuilder) {
+
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory();
+        requestFactory.setReadTimeout(Duration.ofSeconds(15));
+        
+        this.restClient = restClientBuilder
+                .baseUrl(routeEngineUrl)
+                .requestFactory(requestFactory)
+                .build();
+    }
+
+    public RouteDto.Response getRoute(RouteDto.Request request) {
+        int maxRetries = 3;
+        for (int i = 0; i < maxRetries; i++) {
+            try {
+                log.info("Requesting route from engine (Attempt {}): lat={}, lon={}, distance={}", 
+                         i + 1, request.lat(), request.lon(), request.distance());
+                         
+                return restClient.get()
+                        .uri(uriBuilder -> uriBuilder
+                                .path("/api/v1/route")
+                                .queryParam("lat", request.lat())
+                                .queryParam("lon", request.lon())
+                                .queryParam("distance", request.distance())
+                                .queryParam("mode", request.mode())
+                                .build())
+                        .retrieve()
+                        .body(RouteDto.Response.class);
+                        
+            } catch (RestClientException e) {
+                log.warn("Route Engine API call failed on attempt {}: {}", i + 1, e.getMessage());
+                if (i == maxRetries - 1) {
+                    log.error("All {} attempts failed for Route Engine API.", maxRetries, e);
+                    throw new RouteException(RouteErrorCode.ROUTE_ENGINE_CONNECTION_FAILED);
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RouteException(RouteErrorCode.ROUTE_CALCULATION_FAILED);
+                }
+            }
+        }
+        throw new RouteException(RouteErrorCode.ROUTE_ENGINE_CONNECTION_FAILED);
+    }
+}

--- a/src/main/java/com/flover/flover_be/route/client/RouteEngineClient.java
+++ b/src/main/java/com/flover/flover_be/route/client/RouteEngineClient.java
@@ -7,14 +7,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestClientException;
 
+import java.net.http.HttpClient;
 import java.time.Duration;
 
 @Slf4j
 @Component
 public class RouteEngineClient {
+
+    private static final int MAX_RETRIES = 3;
 
     private final RestClient restClient;
 
@@ -22,47 +26,51 @@ public class RouteEngineClient {
             @Value("${route.engine.url}") String routeEngineUrl,
             RestClient.Builder restClientBuilder) {
 
-        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory();
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
         requestFactory.setReadTimeout(Duration.ofSeconds(15));
-        
+
         this.restClient = restClientBuilder
                 .baseUrl(routeEngineUrl)
                 .requestFactory(requestFactory)
                 .build();
     }
 
-    public RouteDto.Response getRoute(RouteDto.Request request) {
-        int maxRetries = 3;
-        for (int i = 0; i < maxRetries; i++) {
+    public RouteDto.Response getRoute(double lat, double lon, int distance, String mode) {
+        Exception lastException = null;
+        for (int i = 0; i < MAX_RETRIES; i++) {
             try {
-                log.info("Requesting route from engine (Attempt {}): lat={}, lon={}, distance={}", 
-                         i + 1, request.lat(), request.lon(), request.distance());
-                         
+                log.info("Requesting route from engine (Attempt {}): lat={}, lon={}, distance={}",
+                         i + 1, lat, lon, distance);
+
                 return restClient.get()
                         .uri(uriBuilder -> uriBuilder
                                 .path("/api/v1/route")
-                                .queryParam("lat", request.lat())
-                                .queryParam("lon", request.lon())
-                                .queryParam("distance", request.distance())
-                                .queryParam("mode", request.mode())
+                                .queryParam("lat", lat)
+                                .queryParam("lon", lon)
+                                .queryParam("distance", distance)
+                                .queryParam("mode", mode)
                                 .build())
                         .retrieve()
                         .body(RouteDto.Response.class);
-                        
-            } catch (RestClientException e) {
+
+            } catch (ResourceAccessException | HttpServerErrorException e) {
                 log.warn("Route Engine API call failed on attempt {}: {}", i + 1, e.getMessage());
-                if (i == maxRetries - 1) {
-                    log.error("All {} attempts failed for Route Engine API.", maxRetries, e);
-                    throw new RouteException(RouteErrorCode.ROUTE_ENGINE_CONNECTION_FAILED);
-                }
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    throw new RouteException(RouteErrorCode.ROUTE_CALCULATION_FAILED);
+                lastException = e;
+                if (i < MAX_RETRIES - 1) {
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RouteException(RouteErrorCode.ROUTE_CALCULATION_FAILED);
+                    }
                 }
             }
         }
+        log.error("All {} attempts failed for Route Engine API.", MAX_RETRIES, lastException);
         throw new RouteException(RouteErrorCode.ROUTE_ENGINE_CONNECTION_FAILED);
     }
 }

--- a/src/main/java/com/flover/flover_be/route/controller/RouteController.java
+++ b/src/main/java/com/flover/flover_be/route/controller/RouteController.java
@@ -2,13 +2,16 @@ package com.flover.flover_be.route.controller;
 
 import com.flover.flover_be.route.client.RouteEngineClient;
 import com.flover.flover_be.route.dto.RouteDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequestMapping("/api/v1/routes")
 @RequiredArgsConstructor
@@ -17,17 +20,10 @@ public class RouteController {
     private final RouteEngineClient routeEngineClient;
 
     @GetMapping
-    public ResponseEntity<RouteDto.Response> getPloggingRoute(
-            @RequestParam double lat,
-            @RequestParam double lon,
-            @RequestParam int time,
-            @RequestParam(defaultValue = "PLOGGING") String mode) {
-        
-        int distance = (int) ((time / 60.0) * 5000);
-        
-        RouteDto.Request request = new RouteDto.Request(lat, lon, distance, mode);
-        RouteDto.Response response = routeEngineClient.getRoute(request);
-        
+    public ResponseEntity<RouteDto.Response> getPloggingRoute(@Valid @ModelAttribute RouteDto.Request request) {
+        int distance = (int) ((request.time() / 60.0) * 5000);
+        RouteDto.Response response = routeEngineClient.getRoute(
+                request.lat(), request.lon(), distance, request.mode());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/flover/flover_be/route/controller/RouteController.java
+++ b/src/main/java/com/flover/flover_be/route/controller/RouteController.java
@@ -1,0 +1,33 @@
+package com.flover.flover_be.route.controller;
+
+import com.flover.flover_be.route.client.RouteEngineClient;
+import com.flover.flover_be.route.dto.RouteDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/routes")
+@RequiredArgsConstructor
+public class RouteController {
+
+    private final RouteEngineClient routeEngineClient;
+
+    @GetMapping
+    public ResponseEntity<RouteDto.Response> getPloggingRoute(
+            @RequestParam double lat,
+            @RequestParam double lon,
+            @RequestParam int time,
+            @RequestParam(defaultValue = "PLOGGING") String mode) {
+        
+        int distance = (int) ((time / 60.0) * 5000);
+        
+        RouteDto.Request request = new RouteDto.Request(lat, lon, distance, mode);
+        RouteDto.Response response = routeEngineClient.getRoute(request);
+        
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/flover/flover_be/route/dto/RouteDto.java
+++ b/src/main/java/com/flover/flover_be/route/dto/RouteDto.java
@@ -1,0 +1,19 @@
+package com.flover.flover_be.route.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public class RouteDto {
+    public record Request(
+            double lat,
+            double lon,
+            @Positive int distance,
+            @NotBlank String mode
+    ) {}
+
+    public record Response(
+            double distanceMeter,
+            long timeMillis,
+            String encodedPath
+    ) {}
+}

--- a/src/main/java/com/flover/flover_be/route/dto/RouteDto.java
+++ b/src/main/java/com/flover/flover_be/route/dto/RouteDto.java
@@ -1,15 +1,21 @@
 package com.flover.flover_be.route.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public class RouteDto {
     public record Request(
-            double lat,
-            double lon,
-            @Positive int distance,
-            @NotBlank String mode
-    ) {}
+            @NotNull Double lat,
+            @NotNull Double lon,
+            @NotNull @Positive Integer time,
+            String mode
+    ) {
+        public Request {
+            if (mode == null || mode.isBlank()) {
+                mode = "PLOGGING";
+            }
+        }
+    }
 
     public record Response(
             double distanceMeter,

--- a/src/main/java/com/flover/flover_be/route/exception/RouteErrorCode.java
+++ b/src/main/java/com/flover/flover_be/route/exception/RouteErrorCode.java
@@ -1,0 +1,16 @@
+package com.flover.flover_be.route.exception;
+
+import com.flover.flover_be.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RouteErrorCode implements ErrorCode {
+    ROUTE_ENGINE_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "라우팅 엔진 서버와의 통신에 실패했습니다."),
+    ROUTE_CALCULATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "라우팅 경로 계산 중 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/flover/flover_be/route/exception/RouteException.java
+++ b/src/main/java/com/flover/flover_be/route/exception/RouteException.java
@@ -1,0 +1,10 @@
+package com.flover.flover_be.route.exception;
+
+import com.flover.flover_be.global.exception.BusinessException;
+import com.flover.flover_be.global.exception.ErrorCode;
+
+public class RouteException extends BusinessException {
+    public RouteException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,8 @@ jwt.expiration=${JWT_EXPIRATION}
 ai.server.url=${AI_SERVER_URL}
 ai.api.key=${AI_API_KEY}
 
+route.engine.url=${ROUTE_ENGINE_URL:http://localhost:8989}
+
 # AWS S3
 aws.region=${AWS_REGION:ap-northeast-2}
 aws.s3.bucket=${AWS_S3_BUCKET:plover-be}

--- a/src/test/java/com/flover/flover_be/route/controller/RouteControllerTest.java
+++ b/src/test/java/com/flover/flover_be/route/controller/RouteControllerTest.java
@@ -1,0 +1,156 @@
+package com.flover.flover_be.route.controller;
+
+import com.flover.flover_be.global.exception.GlobalExceptionHandler;
+import com.flover.flover_be.route.client.RouteEngineClient;
+import com.flover.flover_be.route.dto.RouteDto;
+import com.flover.flover_be.route.exception.RouteErrorCode;
+import com.flover.flover_be.route.exception.RouteException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class RouteControllerTest {
+
+    @Mock
+    private RouteEngineClient routeEngineClient;
+
+    @InjectMocks
+    private RouteController controller;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @DisplayName("정상 요청 시 200 OK와 경로 데이터를 반환한다")
+    @Test
+    void get_plogging_route_성공_200_반환() throws Exception {
+        // given
+        RouteDto.Response mockResponse = new RouteDto.Response(2500.0, 605000, "encodedPathData");
+        given(routeEngineClient.getRoute(any(RouteDto.Request.class))).willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/routes")
+                        .param("lat", "35.1769")
+                        .param("lon", "126.9058")
+                        .param("time", "30")
+                        .param("mode", "PLOGGING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.distanceMeter").value(2500.0))
+                .andExpect(jsonPath("$.timeMillis").value(605000))
+                .andExpect(jsonPath("$.encodedPath").value("encodedPathData"));
+    }
+
+    @DisplayName("time 파라미터가 30분일 때 distance 2500m로 변환되어 전달된다")
+    @Test
+    void get_plogging_route_시간_거리_변환_검증() throws Exception {
+        // given
+        RouteDto.Response mockResponse = new RouteDto.Response(2500.0, 605000, "encodedPathData");
+        given(routeEngineClient.getRoute(any(RouteDto.Request.class))).willReturn(mockResponse);
+
+        // when
+        mockMvc.perform(get("/api/v1/routes")
+                        .param("lat", "35.1769")
+                        .param("lon", "126.9058")
+                        .param("time", "30"))
+                .andExpect(status().isOk());
+
+        // then
+        org.mockito.ArgumentCaptor<RouteDto.Request> captor =
+                org.mockito.ArgumentCaptor.forClass(RouteDto.Request.class);
+        verify(routeEngineClient).getRoute(captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().distance()).isEqualTo(2500);
+    }
+
+    @DisplayName("mode 미지정 시 기본값 PLOGGING이 적용된다")
+    @Test
+    void get_plogging_route_기본_모드_PLOGGING() throws Exception {
+        // given
+        RouteDto.Response mockResponse = new RouteDto.Response(2500.0, 605000, "encodedPathData");
+        given(routeEngineClient.getRoute(any(RouteDto.Request.class))).willReturn(mockResponse);
+
+        // when
+        mockMvc.perform(get("/api/v1/routes")
+                        .param("lat", "35.1769")
+                        .param("lon", "126.9058")
+                        .param("time", "30"))
+                .andExpect(status().isOk());
+
+        // then
+        org.mockito.ArgumentCaptor<RouteDto.Request> captor =
+                org.mockito.ArgumentCaptor.forClass(RouteDto.Request.class);
+        verify(routeEngineClient).getRoute(captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().mode()).isEqualTo("PLOGGING");
+    }
+
+    @DisplayName("lat 파라미터 누락 시 400을 반환한다")
+    @Test
+    void get_plogging_route_lat_누락_400_반환() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/routes")
+                        .param("lon", "126.9058")
+                        .param("time", "30"))
+                .andExpect(status().isBadRequest());
+
+        verify(routeEngineClient, never()).getRoute(any());
+    }
+
+    @DisplayName("lon 파라미터 누락 시 400을 반환한다")
+    @Test
+    void get_plogging_route_lon_누락_400_반환() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/routes")
+                        .param("lat", "35.1769")
+                        .param("time", "30"))
+                .andExpect(status().isBadRequest());
+
+        verify(routeEngineClient, never()).getRoute(any());
+    }
+
+    @DisplayName("time 파라미터 누락 시 400을 반환한다")
+    @Test
+    void get_plogging_route_time_누락_400_반환() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/routes")
+                        .param("lat", "35.1769")
+                        .param("lon", "126.9058"))
+                .andExpect(status().isBadRequest());
+
+        verify(routeEngineClient, never()).getRoute(any());
+    }
+
+    @DisplayName("라우팅 엔진 통신 실패 시 503을 반환한다")
+    @Test
+    void get_plogging_route_엔진_실패_503_반환() throws Exception {
+        // given
+        given(routeEngineClient.getRoute(any(RouteDto.Request.class)))
+                .willThrow(new RouteException(RouteErrorCode.ROUTE_ENGINE_CONNECTION_FAILED));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/routes")
+                        .param("lat", "35.1769")
+                        .param("lon", "126.9058")
+                        .param("time", "30")
+                        .param("mode", "PLOGGING"))
+                .andExpect(status().isServiceUnavailable());
+    }
+}

--- a/src/test/java/com/flover/flover_be/route/controller/RouteControllerTest.java
+++ b/src/test/java/com/flover/flover_be/route/controller/RouteControllerTest.java
@@ -14,8 +14,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -38,6 +41,7 @@ class RouteControllerTest {
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(new LocalValidatorFactoryBean())
                 .build();
     }
 
@@ -46,7 +50,8 @@ class RouteControllerTest {
     void get_plogging_route_성공_200_반환() throws Exception {
         // given
         RouteDto.Response mockResponse = new RouteDto.Response(2500.0, 605000, "encodedPathData");
-        given(routeEngineClient.getRoute(any(RouteDto.Request.class))).willReturn(mockResponse);
+        given(routeEngineClient.getRoute(anyDouble(), anyDouble(), anyInt(), anyString()))
+                .willReturn(mockResponse);
 
         // when & then
         mockMvc.perform(get("/api/v1/routes")
@@ -65,7 +70,8 @@ class RouteControllerTest {
     void get_plogging_route_시간_거리_변환_검증() throws Exception {
         // given
         RouteDto.Response mockResponse = new RouteDto.Response(2500.0, 605000, "encodedPathData");
-        given(routeEngineClient.getRoute(any(RouteDto.Request.class))).willReturn(mockResponse);
+        given(routeEngineClient.getRoute(anyDouble(), anyDouble(), anyInt(), anyString()))
+                .willReturn(mockResponse);
 
         // when
         mockMvc.perform(get("/api/v1/routes")
@@ -75,10 +81,10 @@ class RouteControllerTest {
                 .andExpect(status().isOk());
 
         // then
-        org.mockito.ArgumentCaptor<RouteDto.Request> captor =
-                org.mockito.ArgumentCaptor.forClass(RouteDto.Request.class);
-        verify(routeEngineClient).getRoute(captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getValue().distance()).isEqualTo(2500);
+        org.mockito.ArgumentCaptor<Integer> distanceCaptor =
+                org.mockito.ArgumentCaptor.forClass(Integer.class);
+        verify(routeEngineClient).getRoute(anyDouble(), anyDouble(), distanceCaptor.capture(), anyString());
+        org.assertj.core.api.Assertions.assertThat(distanceCaptor.getValue()).isEqualTo(2500);
     }
 
     @DisplayName("mode 미지정 시 기본값 PLOGGING이 적용된다")
@@ -86,7 +92,8 @@ class RouteControllerTest {
     void get_plogging_route_기본_모드_PLOGGING() throws Exception {
         // given
         RouteDto.Response mockResponse = new RouteDto.Response(2500.0, 605000, "encodedPathData");
-        given(routeEngineClient.getRoute(any(RouteDto.Request.class))).willReturn(mockResponse);
+        given(routeEngineClient.getRoute(anyDouble(), anyDouble(), anyInt(), anyString()))
+                .willReturn(mockResponse);
 
         // when
         mockMvc.perform(get("/api/v1/routes")
@@ -96,10 +103,10 @@ class RouteControllerTest {
                 .andExpect(status().isOk());
 
         // then
-        org.mockito.ArgumentCaptor<RouteDto.Request> captor =
-                org.mockito.ArgumentCaptor.forClass(RouteDto.Request.class);
-        verify(routeEngineClient).getRoute(captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getValue().mode()).isEqualTo("PLOGGING");
+        org.mockito.ArgumentCaptor<String> modeCaptor =
+                org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(routeEngineClient).getRoute(anyDouble(), anyDouble(), anyInt(), modeCaptor.capture());
+        org.assertj.core.api.Assertions.assertThat(modeCaptor.getValue()).isEqualTo("PLOGGING");
     }
 
     @DisplayName("lat 파라미터 누락 시 400을 반환한다")
@@ -111,7 +118,7 @@ class RouteControllerTest {
                         .param("time", "30"))
                 .andExpect(status().isBadRequest());
 
-        verify(routeEngineClient, never()).getRoute(any());
+        verify(routeEngineClient, never()).getRoute(anyDouble(), anyDouble(), anyInt(), anyString());
     }
 
     @DisplayName("lon 파라미터 누락 시 400을 반환한다")
@@ -123,7 +130,7 @@ class RouteControllerTest {
                         .param("time", "30"))
                 .andExpect(status().isBadRequest());
 
-        verify(routeEngineClient, never()).getRoute(any());
+        verify(routeEngineClient, never()).getRoute(anyDouble(), anyDouble(), anyInt(), anyString());
     }
 
     @DisplayName("time 파라미터 누락 시 400을 반환한다")
@@ -135,14 +142,27 @@ class RouteControllerTest {
                         .param("lon", "126.9058"))
                 .andExpect(status().isBadRequest());
 
-        verify(routeEngineClient, never()).getRoute(any());
+        verify(routeEngineClient, never()).getRoute(anyDouble(), anyDouble(), anyInt(), anyString());
+    }
+
+    @DisplayName("time이 0 이하일 때 400을 반환한다")
+    @Test
+    void get_plogging_route_time_0이하_400_반환() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/routes")
+                        .param("lat", "35.1769")
+                        .param("lon", "126.9058")
+                        .param("time", "0"))
+                .andExpect(status().isBadRequest());
+
+        verify(routeEngineClient, never()).getRoute(anyDouble(), anyDouble(), anyInt(), anyString());
     }
 
     @DisplayName("라우팅 엔진 통신 실패 시 503을 반환한다")
     @Test
     void get_plogging_route_엔진_실패_503_반환() throws Exception {
         // given
-        given(routeEngineClient.getRoute(any(RouteDto.Request.class)))
+        given(routeEngineClient.getRoute(anyDouble(), anyDouble(), anyInt(), anyString()))
                 .willThrow(new RouteException(RouteErrorCode.ROUTE_ENGINE_CONNECTION_FAILED));
 
         // when & then


### PR DESCRIPTION
## 관련 이슈
- close # (이슈 번호)

## 작업 내용
- Route Engine(plover-route) 연동을 위한 route 도메인 패키지 신규 생성
- RestClient 기반 HTTP 클라이언트 구현 (타임아웃 5s/15s, 최대 3회 재시도)
- 클라이언트 요청 파라미터를 time(분)으로 받아 5km/h 기준 distance(m)로 내부 변환
- RouteErrorCode, RouteException 추가 (기존 GlobalExceptionHandler 연동)
- DTO는 Java Record Inner Class 패턴 적용 (RouteDto.Request, RouteDto.Response)
- application.properties에 ROUTE_ENGINE_URL 환경변수 분리 (기본값 localhost:8989)
- RouteControllerTest 단위 테스트 7건 작성 (정상 응답, 시간→거리 변환, 기본 mode, 파라미터 누락, 엔진 실패)

## 테스트
- [ ] 로컬에서 정상 동작을 확인했습니다. (음... 로컬로 테스트가 불가능한 영역입니다..)
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다. (controller 테스트는 추가했습니다.)

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.