### PR TITLE
[bugfix]: RouteEngineClient RestClient.Builder 빈 주입 제거

### DIFF
--- a/src/main/java/com/flover/flover_be/route/client/RouteEngineClient.java
+++ b/src/main/java/com/flover/flover_be/route/client/RouteEngineClient.java
@@ -22,10 +22,7 @@ public class RouteEngineClient {
 
     private final RestClient restClient;
 
-    public RouteEngineClient(
-            @Value("${route.engine.url}") String routeEngineUrl,
-            RestClient.Builder restClientBuilder) {
-
+    public RouteEngineClient(@Value("${route.engine.url}") String routeEngineUrl) {
         HttpClient httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(5))
                 .build();
@@ -33,7 +30,7 @@ public class RouteEngineClient {
         JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
         requestFactory.setReadTimeout(Duration.ofSeconds(15));
 
-        this.restClient = restClientBuilder
+        this.restClient = RestClient.builder()
                 .baseUrl(routeEngineUrl)
                 .requestFactory(requestFactory)
                 .build();


### PR DESCRIPTION
## 관련 이슈
- close #47 

## 작업 내용
- `RouteEngineClient` 생성자에서 `RestClient.Builder` 빈 주입을 제거했습니다.
- `RestClient.builder()` 정적 메서드를 사용해 직접 생성하도록 수정했습니다.
- Spring Boot 4.x 환경에서 `RestClient.Builder`가 자동 구성 빈으로 등록되지 않아 발생하던 애플리케이션 실행 실패 문제를 해결했습니다.

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.