### PR TITLE
[docs]: HTML 버전의 AI 가이드 문서 생성 (정적 리소스 서빙)

### DIFF
--- a/src/main/resources/static/docs/claude_md.html
+++ b/src/main/resources/static/docs/claude_md.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CLAUDE.md — AI 코딩 가이드라인</title>
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
+      --green: #3fb950; --yellow: #d29922; --red: #f85149;
+      --purple: #bc8cff; --code-bg: #1f2937;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans KR, sans-serif;
+      background: var(--bg); color: var(--text); line-height: 1.75; padding: 2rem 1rem;
+    }
+    .container { max-width: 860px; margin: 0 auto; }
+    header { border-bottom: 1px solid var(--border); padding-bottom: 1.5rem; margin-bottom: 2rem; }
+    header h1 { font-size: 1.8rem; color: var(--accent); }
+    header p { color: var(--muted); font-size: 0.9rem; margin-top: 0.3rem; }
+    nav { margin-bottom: 2rem; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.85rem; margin-right: 1rem; }
+    nav a:hover { color: var(--accent); }
+    h2 { font-size: 1.2rem; color: var(--accent); border-left: 3px solid var(--accent); padding-left: 0.75rem; margin: 2.5rem 0 1rem; }
+    p { margin: 0.6rem 0; }
+    code { background: var(--code-bg); color: #79c0ff; padding: 0.15em 0.45em; border-radius: 4px; font-family: "JetBrains Mono", Consolas, monospace; font-size: 0.88em; }
+    .rule-card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 10px; padding: 1.5rem; margin-bottom: 1.25rem;
+    }
+    .rule-card .num {
+      display: inline-flex; align-items: center; justify-content: center;
+      background: var(--accent); color: #0d1117; font-weight: 700;
+      width: 1.8rem; height: 1.8rem; border-radius: 50%; font-size: 0.9rem;
+      margin-bottom: 0.75rem;
+    }
+    .rule-card h3 { font-size: 1.05rem; color: var(--text); margin-bottom: 0.5rem; }
+    .rule-card .subtitle { font-size: 0.85rem; color: var(--purple); margin-bottom: 0.75rem; font-style: italic; }
+    .checklist { list-style: none; padding: 0; }
+    .checklist li {
+      padding: 0.35rem 0 0.35rem 1.5rem;
+      position: relative; font-size: 0.9rem; color: var(--text);
+      border-bottom: 1px solid #1e2530;
+    }
+    .checklist li:last-child { border-bottom: none; }
+    .checklist li::before { content: "→"; position: absolute; left: 0; color: var(--green); font-size: 0.8rem; top: 0.4rem; }
+    .example-block {
+      background: var(--code-bg); border-left: 3px solid var(--yellow);
+      border-radius: 0 6px 6px 0; padding: 0.75rem 1rem; margin-top: 0.75rem; font-size: 0.85rem;
+    }
+    .example-block .label { color: var(--muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.4rem; }
+    .arrow-item { display: flex; align-items: flex-start; gap: 0.5rem; margin: 0.3rem 0; font-size: 0.88rem; }
+    .arrow-item .from { color: var(--muted); }
+    .arrow-item .arr { color: var(--yellow); flex-shrink: 0; }
+    .arrow-item .to { color: var(--green); }
+    .step-list { counter-reset: step; list-style: none; padding: 0; margin-top: 0.5rem; }
+    .step-list li { counter-increment: step; display: flex; gap: 0.75rem; align-items: flex-start; margin: 0.4rem 0; font-size: 0.88rem; }
+    .step-list li::before { content: counter(step) "."; color: var(--accent); font-weight: 700; flex-shrink: 0; }
+    .tradeoff { background: #0e1a0e; border: 1px solid #2d4a2d; border-radius: 8px; padding: 0.75rem 1rem; margin-bottom: 2rem; font-size: 0.88rem; color: #7ee787; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a href="index.html">← 목록으로</a>
+      <a href="skills.html">기술 스택</a>
+      <a href="code_convention.html">코드 컨벤션</a>
+      <a href="workflow.html">워크플로우</a>
+      <a href="test_convention.html">테스트 컨벤션</a>
+    </nav>
+
+    <header>
+      <h1>CLAUDE.md</h1>
+      <p>AI 코딩 실수를 줄이기 위한 행동 가이드라인</p>
+    </header>
+
+    <div class="tradeoff">
+      Tradeoff: 이 가이드라인은 속도보다 신중함을 우선합니다. 사소한 작업은 판단에 맡깁니다.
+    </div>
+
+    <!-- Rule 1 -->
+    <div class="rule-card">
+      <div class="num">1</div>
+      <h3>Think Before Coding</h3>
+      <div class="subtitle">가정하지 말 것. 혼란을 숨기지 말 것. 트레이드오프를 드러낼 것.</div>
+      <p style="font-size:0.85rem; color:var(--muted); margin-bottom:0.75rem;">구현 전 반드시:</p>
+      <ul class="checklist">
+        <li>가정을 명시적으로 밝힌다. 불확실하면 질문한다.</li>
+        <li>여러 해석이 가능하면 모두 제시한다 — 혼자 선택하지 않는다.</li>
+        <li>더 단순한 방법이 있으면 말한다. 필요하면 반론을 제기한다.</li>
+        <li>불명확한 게 있으면 멈춘다. 무엇이 혼란스러운지 명시하고 질문한다.</li>
+      </ul>
+    </div>
+
+    <!-- Rule 2 -->
+    <div class="rule-card">
+      <div class="num">2</div>
+      <h3>Simplicity First</h3>
+      <div class="subtitle">문제를 해결하는 최소한의 코드. 추측성 코드는 없다.</div>
+      <ul class="checklist">
+        <li>요청받은 것 이상의 기능을 추가하지 않는다.</li>
+        <li>한 번만 쓰는 코드에 추상화를 만들지 않는다.</li>
+        <li>요청받지 않은 "유연성"이나 "설정 가능성"을 넣지 않는다.</li>
+        <li>불가능한 시나리오에 대한 에러 핸들링을 넣지 않는다.</li>
+        <li>200줄로 짰는데 50줄로 될 것 같으면 다시 짠다.</li>
+      </ul>
+      <div class="example-block">
+        <div class="label">자가진단</div>
+        "시니어 엔지니어가 봤을 때 이게 과하게 복잡해 보일까?" → 그렇다면 단순화한다.
+      </div>
+    </div>
+
+    <!-- Rule 3 -->
+    <div class="rule-card">
+      <div class="num">3</div>
+      <h3>Surgical Changes</h3>
+      <div class="subtitle">반드시 건드려야 하는 것만 건드린다. 자신이 만든 mess만 정리한다.</div>
+      <p style="font-size:0.85rem; color:var(--muted); margin-bottom:0.5rem;">기존 코드 수정 시:</p>
+      <ul class="checklist">
+        <li>인접 코드, 주석, 포매팅을 "개선"하지 않는다.</li>
+        <li>고장나지 않은 것을 리팩토링하지 않는다.</li>
+        <li>다르게 하고 싶더라도 기존 스타일에 맞춘다.</li>
+        <li>관련 없는 죽은 코드를 발견하면 알리되 삭제하지 않는다.</li>
+      </ul>
+      <p style="font-size:0.85rem; color:var(--muted); margin: 0.75rem 0 0.5rem;">변경으로 인해 고아가 된 코드:</p>
+      <ul class="checklist">
+        <li><strong style="color:var(--green)">내 변경이 만든</strong> 미사용 import/변수/함수는 제거한다.</li>
+        <li>기존에 있던 죽은 코드는 요청받지 않는 한 건드리지 않는다.</li>
+      </ul>
+      <div class="example-block">
+        <div class="label">판단 기준</div>
+        변경된 모든 줄이 사용자의 요청에 직접 연결되어야 한다.
+      </div>
+    </div>
+
+    <!-- Rule 4 -->
+    <div class="rule-card">
+      <div class="num">4</div>
+      <h3>Goal-Driven Execution</h3>
+      <div class="subtitle">성공 기준을 정의한다. 검증될 때까지 반복한다.</div>
+      <p style="font-size:0.85rem; color:var(--muted); margin-bottom:0.5rem;">작업을 검증 가능한 목표로 변환:</p>
+      <div class="example-block">
+        <div class="label">변환 예시</div>
+        <div class="arrow-item">
+          <span class="from">"검증 추가"</span>
+          <span class="arr">→</span>
+          <span class="to">"잘못된 입력 테스트 작성 후 통과시키기"</span>
+        </div>
+        <div class="arrow-item">
+          <span class="from">"버그 수정"</span>
+          <span class="arr">→</span>
+          <span class="to">"재현 테스트 작성 후 통과시키기"</span>
+        </div>
+        <div class="arrow-item">
+          <span class="from">"X 리팩토링"</span>
+          <span class="arr">→</span>
+          <span class="to">"전후 테스트 통과 보장"</span>
+        </div>
+      </div>
+      <p style="font-size:0.85rem; color:var(--muted); margin: 0.75rem 0 0.5rem;">다단계 작업 시 간략한 계획 제시:</p>
+      <ol class="step-list">
+        <li><span>[단계] → 검증: [확인 방법]</span></li>
+        <li><span>[단계] → 검증: [확인 방법]</span></li>
+        <li><span>[단계] → 검증: [확인 방법]</span></li>
+      </ol>
+    </div>
+
+    <div style="margin-top:2rem; padding:1rem; border:1px solid var(--border); border-radius:8px; font-size:0.85rem; color:var(--muted);">
+      이 가이드라인이 잘 작동하는 신호: diff에서 불필요한 변경 감소 · 과복잡으로 인한 재작성 감소 · 실수 후가 아닌 구현 전에 명확화 질문이 나오는 것.
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/static/docs/code_convention.html
+++ b/src/main/resources/static/docs/code_convention.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>코드 컨벤션 — flover-be</title>
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
+      --green: #3fb950; --yellow: #d29922; --red: #f85149; --purple: #bc8cff;
+      --code-bg: #1f2937; --tag-bg: #1c2a3e;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans KR, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; padding: 2rem 1rem; }
+    .container { max-width: 900px; margin: 0 auto; }
+    header { border-bottom: 1px solid var(--border); padding-bottom: 1.5rem; margin-bottom: 2rem; }
+    header h1 { font-size: 1.8rem; color: var(--accent); }
+    header p { color: var(--muted); font-size: 0.9rem; margin-top: 0.3rem; }
+    nav { margin-bottom: 2rem; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.85rem; margin-right: 1rem; }
+    nav a:hover { color: var(--accent); }
+    h2 { font-size: 1.2rem; color: var(--accent); border-left: 3px solid var(--accent); padding-left: 0.75rem; margin: 2.5rem 0 1rem; }
+    h3 { font-size: 1rem; color: var(--purple); margin: 1.25rem 0 0.6rem; }
+    ul, ol { padding-left: 1.5rem; }
+    li { margin: 0.4rem 0; }
+    code { background: var(--code-bg); color: #79c0ff; padding: 0.15em 0.45em; border-radius: 4px; font-family: "JetBrains Mono", "Fira Code", Consolas, monospace; font-size: 0.88em; }
+    strong { color: #ffa657; }
+    pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.25rem; overflow-x: auto; margin: 0.75rem 0; font-family: "JetBrains Mono", "Fira Code", Consolas, monospace; font-size: 0.85rem; line-height: 1.6; color: #c9d1d9; }
+    pre .kw { color: #ff7b72; } pre .str { color: #a5d6ff; } pre .cmt { color: #8b949e; font-style: italic; } pre .ann { color: #d2a8ff; } pre .cls { color: #ffa657; }
+    .section { margin-bottom: 2rem; }
+    .warn { background: #1a0e0e; border-left: 3px solid var(--red); padding: 0.75rem 1rem; border-radius: 0 6px 6px 0; margin-top: 0.75rem; }
+    .warn li { color: #ffa198; }
+    .warn code { background: #2a1515; color: #ff9492; }
+    .tree { background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.25rem; font-family: "JetBrains Mono", "Fira Code", Consolas, monospace; font-size: 0.85rem; color: #c9d1d9; white-space: pre; overflow-x: auto; }
+    .rule-list { list-style: none; padding: 0; }
+    .rule-list li { padding: 0.5rem 1rem; border-left: 2px solid var(--border); margin-bottom: 0.4rem; }
+    .flow-steps { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin: 0.75rem 0; }
+    .flow-step { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 0.4em 0.9em; font-size: 0.85rem; font-family: "JetBrains Mono", Consolas, monospace; color: var(--green); }
+    .flow-arrow { color: var(--muted); font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a href="index.html">← 목록으로</a>
+      <a href="claude_md.html">CLAUDE.md</a>
+      <a href="skills.html">기술 스택</a>
+      <a href="workflow.html">워크플로우</a>
+      <a href="test_convention.html">테스트 컨벤션</a>
+    </nav>
+    <header>
+      <h1>코드 컨벤션</h1>
+      <p>패키지 구조, DTO, Entity, 예외 처리, JPQL 집계 패턴, 안티패턴</p>
+    </header>
+
+    <div class="section">
+      <h2>패키지 구조</h2>
+      <ul class="rule-list">
+        <li>도메인 기반 패키지 구조를 사용한다.</li>
+        <li>루트 패키지: <code>com.flover.flover_be</code></li>
+        <li>각 도메인 하위에 <code>controller</code> / <code>service</code> / <code>repository</code> / <code>domain</code> / <code>dto</code> 패키지를 둔다.</li>
+      </ul>
+      <div class="tree" style="margin-top:0.75rem;">com.flover.flover_be
+├── user/
+│   ├── controller/
+│   ├── service/
+│   ├── repository/
+│   ├── domain/    ← Entity 클래스
+│   ├── exception/ ← 도메인 ErrorCode enum, 도메인 Exception 클래스
+│   └── dto/
+├── order/
+│   ├── controller/
+│   ├── service/
+│   ├── repository/
+│   ├── domain/
+│   ├── exception/
+│   └── dto/
+└── global/
+    ├── exception/ ← ErrorCode(interface), CommonErrorCode, BusinessException, GlobalExceptionHandler
+    └── response/</div>
+    </div>
+
+    <div class="section">
+      <h2>DTO</h2>
+      <ul class="rule-list">
+        <li>Request/Response DTO는 Java <strong>Record</strong>로 작성한다.</li>
+        <li>DTO에 Jakarta Validation 어노테이션을 직접 선언한다.</li>
+        <li>요청과 응답 DTO를 분리한다.</li>
+        <li>Inner class 패턴으로 관련 DTO를 그룹핑한다.</li>
+      </ul>
+      <pre><span class="kw">public class</span> <span class="cls">UserDto</span> {
+    <span class="kw">public record</span> <span class="cls">Request</span>(<span class="ann">@NotBlank</span> String name, <span class="ann">@Email</span> String email) {}
+    <span class="kw">public record</span> <span class="cls">Response</span>(Long id, String name, String email) {}
+}</pre>
+    </div>
+
+    <div class="section">
+      <h2>Entity</h2>
+      <ul class="rule-list">
+        <li><code>@NoArgsConstructor(access = AccessLevel.PROTECTED)</code>를 사용한다.</li>
+        <li>생성자는 정적 팩토리 메서드(<code>of</code>, <code>create</code>)로 대체한다.</li>
+        <li>엔티티를 API 응답으로 직접 노출하지 않는다.</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>빌더 패턴</h2>
+      <ul class="rule-list">
+        <li>필드가 많거나 생성자가 복잡한 경우 빌더 패턴 사용을 고려한다.</li>
+        <li>가독성과 유지보수를 위해 의미 있는 필드만 선택적으로 설정할 수 있도록 한다.</li>
+        <li>DTO 또는 테스트 객체 생성 시 적극적으로 활용한다.</li>
+        <li>엔티티의 생성 규칙을 우회하는 무분별한 빌더 사용은 지양한다.</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>예외 처리</h2>
+      <ul class="rule-list">
+        <li><code>ErrorCode</code>는 <code>global/exception/</code>에 <strong>인터페이스</strong>로 선언한다.</li>
+        <li>도메인 공통 에러: <code>global/exception/CommonErrorCode</code></li>
+        <li>도메인별 에러: <code>{domain}/exception/{Domain}ErrorCode</code></li>
+        <li>도메인별 커스텀 예외는 <code>BusinessException</code>을 상속하며 <code>ErrorCode</code>를 인자로 받는다.</li>
+        <li><code>GlobalExceptionHandler</code>(<code>@RestControllerAdvice</code>)에서 모든 예외를 공통 처리한다.</li>
+        <li>에러 응답은 <code>ErrorResponse</code> DTO로 통일한다.</li>
+      </ul>
+      <pre><span class="cmt">// global: ErrorCode 인터페이스</span>
+<span class="kw">public interface</span> <span class="cls">ErrorCode</span> {
+    HttpStatus getStatus();
+    String getMessage();
+}
+
+<span class="cmt">// global: 서버 공통 에러</span>
+<span class="kw">public enum</span> <span class="cls">CommonErrorCode</span> <span class="kw">implements</span> <span class="cls">ErrorCode</span> {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, <span class="str">"서버 내부 오류가 발생했습니다."</span>);
+}
+
+<span class="cmt">// user: 도메인 에러코드</span>
+<span class="kw">public enum</span> <span class="cls">AuthErrorCode</span> <span class="kw">implements</span> <span class="cls">ErrorCode</span> {
+    KAKAO_TOKEN_FAILED(HttpStatus.UNAUTHORIZED, <span class="str">"카카오 토큰 발급에 실패했습니다."</span>);
+}
+
+<span class="cmt">// user: 도메인 예외는 ErrorCode를 받아 부모에게 위임</span>
+<span class="kw">public class</span> <span class="cls">KakaoAuthException</span> <span class="kw">extends</span> <span class="cls">BusinessException</span> {
+    <span class="kw">public</span> KakaoAuthException(ErrorCode errorCode) { <span class="kw">super</span>(errorCode); }
+}</pre>
+    </div>
+
+    <div class="section">
+      <h2>네이밍</h2>
+      <ul class="rule-list">
+        <li>서비스 메서드: 동사 + 목적어 (예: <code>createUser</code>, <code>findUserById</code>)</li>
+        <li>Boolean 반환 메서드: <code>is</code> / <code>has</code> / <code>can</code> 접두사 사용</li>
+        <li>컬렉션 반환: 복수형 사용 (예: <code>findActiveUsers</code>)</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>환경변수 관리</h2>
+      <ul class="rule-list">
+        <li>DB 비밀번호, JWT secret, OAuth 키 등 민감한 설정값은 <code>.env</code> 파일에 관리한다.</li>
+        <li><code>application.properties</code>에서 <code>${VAR_NAME}</code> 형식으로 참조한다.</li>
+        <li><code>.env</code>는 <code>.gitignore</code>에 추가한다.</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>API 응답 형식</h2>
+      <ul class="rule-list">
+        <li>성공 응답은 Controller에서 데이터를 직접 반환한다. (<code>ResponseEntity&lt;T&gt;</code> 또는 <code>T</code>)</li>
+        <li>공통 래퍼(<code>ApiResponse&lt;T&gt;</code>)를 사용하지 않는다.</li>
+        <li>에러 응답만 <code>ErrorResponse</code> DTO로 통일한다.</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>S3 파일 업로드 패턴</h2>
+      <ul class="rule-list">
+        <li>파일 업로드는 <strong>Presigned URL</strong> 방식을 사용한다. 서버가 파일을 직접 받지 않는다.</li>
+      </ul>
+      <div class="flow-steps">
+        <span class="flow-step">① GET /upload-url</span>
+        <span class="flow-arrow">→</span>
+        <span class="flow-step">② S3 직접 PUT</span>
+        <span class="flow-arrow">→</span>
+        <span class="flow-step">③ PUT /profile-image</span>
+      </div>
+      <ul class="rule-list">
+        <li>Presigned URL 유효 시간은 <strong>10분</strong>으로 설정한다.</li>
+        <li>허용 Content-Type은 서버에서 검증하며, Presigned URL 서명 시에도 Content-Type을 고정한다.</li>
+        <li><code>S3Client</code>와 <code>S3Presigner</code> 모두 <code>AwsCredentialsProvider</code> Bean을 공유한다.</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>import 규칙</h2>
+      <ul class="rule-list">
+        <li>와일드카드 import(<code>import org.springframework.web.bind.annotation.*</code>)를 사용하지 않는다.</li>
+        <li>항상 사용하는 클래스를 개별로 명시한다.</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>JPQL 집계 쿼리 패턴</h2>
+      <ul class="rule-list">
+        <li>여러 집계값을 조회할 때 단일 JPQL 쿼리로 한 번에 가져온다.</li>
+        <li>결과는 <strong>인터페이스 기반 프로젝션</strong>으로 받는다. 엔티티 전체를 로드하지 않는다.</li>
+        <li>프로젝션 인터페이스는 Repository 인터페이스 내부에 중첩 인터페이스로 선언한다.</li>
+        <li><code>SUM</code> 집계는 <code>COALESCE</code>로 null 대신 0 처리한다.</li>
+      </ul>
+      <pre><span class="ann">@Query</span>(<span class="str">"SELECT COUNT(p) AS count, COALESCE(SUM(p.stepCount), 0) AS totalStepCount, "</span>
+     + <span class="str">"COALESCE(SUM(p.distanceMeters), 0) AS totalDistanceMeters "</span>
+     + <span class="str">"FROM PloggingSession p WHERE p.user.id = :userId"</span>)
+PloggingStatsView findStatsByUserId(<span class="ann">@Param</span>(<span class="str">"userId"</span>) Long userId);
+
+<span class="kw">interface</span> <span class="cls">PloggingStatsView</span> {
+    <span class="kw">long</span> getCount();
+    <span class="kw">long</span> getTotalStepCount();
+    <span class="kw">long</span> getTotalDistanceMeters();
+}</pre>
+    </div>
+
+    <div class="section">
+      <h2>서비스 내 다중 필드 집계 패턴</h2>
+      <ul class="rule-list">
+        <li>컬렉션에서 여러 필드를 합산할 때 필드마다 스트림을 별도로 순회하지 않는다.</li>
+        <li><code>private record</code>를 서비스 내부에 선언하고 <code>from</code>으로 단일 루프에서 집계한다.</li>
+      </ul>
+      <pre><span class="kw">private record</span> <span class="cls">SessionAggregate</span>(<span class="kw">long</span> stepCount, <span class="kw">long</span> distanceMeters, <span class="kw">long</span> caloriesBurned, <span class="kw">long</span> ploggingSeconds) {
+    <span class="kw">static</span> SessionAggregate from(List&lt;SessionStatsView&gt; sessions) {
+        <span class="kw">long</span> stepCount = 0, distanceMeters = 0, caloriesBurned = 0, ploggingSeconds = 0;
+        <span class="kw">for</span> (SessionStatsView s : sessions) {
+            stepCount += s.getStepCount();
+            distanceMeters += s.getDistanceMeters();
+            caloriesBurned += s.getCaloriesBurned();
+            ploggingSeconds += s.getPloggingSeconds();
+        }
+        <span class="kw">return new</span> SessionAggregate(stepCount, distanceMeters, caloriesBurned, ploggingSeconds);
+    }
+}</pre>
+    </div>
+
+    <div class="section">
+      <h2>안티패턴 금지</h2>
+      <div class="warn">
+        <ul>
+          <li>Controller에서 Repository를 직접 호출하지 않는다.</li>
+          <li><code>@Autowired</code> 필드 주입을 사용하지 않는다.</li>
+          <li><code>Optional</code>을 필드나 메서드 파라미터 타입으로 사용하지 않는다.</li>
+          <li>엔티티를 Controller 반환값으로 직접 사용하지 않는다.</li>
+          <li>엔티티에 public setter를 사용하지 않는다.</li>
+          <li>상태 변경은 의미 있는 도메인 메서드를 통해 수행한다. (예: <code>changePassword</code>)</li>
+          <li>표준 Java 예외(<code>IllegalArgumentException</code> 등)를 도메인 로직에서 직접 던지지 않는다. 커스텀 <code>BusinessException</code> 서브클래스를 사용한다.</li>
+          <li>동일한 컬렉션을 필드별로 여러 번 순회해 집계하지 않는다.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>flover-be — AI 가이드</title>
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
+      --green: #3fb950; --yellow: #d29922; --purple: #bc8cff;
+      --code-bg: #1f2937;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans KR, sans-serif;
+      background: var(--bg); color: var(--text); line-height: 1.7; padding: 3rem 1rem;
+    }
+    .container { max-width: 860px; margin: 0 auto; }
+    header { text-align: center; margin-bottom: 3rem; }
+    header h1 { font-size: 2rem; color: var(--accent); letter-spacing: -0.5px; }
+    header p { color: var(--muted); margin-top: 0.5rem; font-size: 0.95rem; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+    a.card {
+      display: block; background: var(--surface); border: 1px solid var(--border);
+      border-radius: 12px; padding: 1.5rem; text-decoration: none;
+      transition: border-color 0.15s, transform 0.1s;
+    }
+    a.card:hover { border-color: var(--accent); transform: translateY(-2px); }
+    a.card.featured { grid-column: 1 / -1; border-color: #1f3a5f; }
+    a.card.featured:hover { border-color: var(--accent); }
+    .card-icon { font-size: 1.8rem; margin-bottom: 0.75rem; }
+    .card h2 { font-size: 1.05rem; color: var(--text); margin-bottom: 0.35rem; }
+    .card p { font-size: 0.85rem; color: var(--muted); line-height: 1.5; }
+    .card .tags { margin-top: 0.75rem; display: flex; flex-wrap: wrap; gap: 0.35rem; }
+    .tag { background: var(--code-bg); border-radius: 4px; padding: 0.15em 0.5em; font-size: 0.75rem; font-family: "JetBrains Mono", Consolas, monospace; color: var(--muted); }
+    footer { text-align: center; margin-top: 3rem; color: var(--muted); font-size: 0.8rem; }
+    @media (max-width: 560px) { .grid { grid-template-columns: 1fr; } a.card.featured { grid-column: auto; } }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>flover-be</h1>
+      <p>AI 코드 가이드 — 행동 지침부터 테스트 컨벤션까지</p>
+    </header>
+
+    <div class="grid">
+
+      <a class="card featured" href="claude_md.html">
+        <div class="card-icon">🤖</div>
+        <h2>CLAUDE.md — AI 코딩 가이드라인</h2>
+        <p>코딩 전 사고 방식, 단순성 우선, 외과적 변경, 목표 기반 실행 — LLM 코딩 실수를 줄이는 4가지 핵심 원칙</p>
+        <div class="tags">
+          <span class="tag">Think Before Coding</span>
+          <span class="tag">Simplicity First</span>
+          <span class="tag">Surgical Changes</span>
+          <span class="tag">Goal-Driven</span>
+        </div>
+      </a>
+
+      <a class="card" href="skills.html">
+        <div class="card-icon">⚙️</div>
+        <h2>기술 스택</h2>
+        <p>Core 라이브러리, 테스트 프레임워크, 패키지 사용 주의사항</p>
+        <div class="tags">
+          <span class="tag">Java 21</span>
+          <span class="tag">Spring Boot</span>
+          <span class="tag">AWS S3</span>
+        </div>
+      </a>
+
+      <a class="card" href="code_convention.html">
+        <div class="card-icon">📐</div>
+        <h2>코드 컨벤션</h2>
+        <p>패키지 구조, DTO, Entity, 예외 처리, JPQL 집계 패턴, 안티패턴</p>
+        <div class="tags">
+          <span class="tag">DTO</span>
+          <span class="tag">Entity</span>
+          <span class="tag">ErrorCode</span>
+          <span class="tag">S3</span>
+        </div>
+      </a>
+
+      <a class="card" href="workflow.html">
+        <div class="card-icon">🔀</div>
+        <h2>개발 워크플로우</h2>
+        <p>기능 개발 순서, 브랜치 전략, 커밋 메시지, PR 규칙</p>
+        <div class="tags">
+          <span class="tag">feature/</span>
+          <span class="tag">Conventional Commits</span>
+        </div>
+      </a>
+
+      <a class="card" href="test_convention.html">
+        <div class="card-icon">🧪</div>
+        <h2>테스트 컨벤션</h2>
+        <p>단위/통합 테스트 구조, Given-When-Then, @Mock vs @Spy</p>
+        <div class="tags">
+          <span class="tag">JUnit 5</span>
+          <span class="tag">Mockito</span>
+          <span class="tag">AssertJ</span>
+        </div>
+      </a>
+
+    </div>
+    <footer>flover-be · AI Guide Docs · Spring Boot 정적 리소스로 서빙</footer>
+  </div>
+</body>
+</html>

--- a/src/main/resources/static/docs/skills.html
+++ b/src/main/resources/static/docs/skills.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>기술 스택 — flover-be</title>
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
+      --green: #3fb950; --yellow: #d29922; --red: #f85149;
+      --code-bg: #1f2937; --tag-bg: #1c2a3e;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans KR, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; padding: 2rem 1rem; }
+    .container { max-width: 860px; margin: 0 auto; }
+    header { border-bottom: 1px solid var(--border); padding-bottom: 1.5rem; margin-bottom: 2rem; }
+    header h1 { font-size: 1.8rem; color: var(--accent); }
+    header p { color: var(--muted); font-size: 0.9rem; margin-top: 0.3rem; }
+    nav { margin-bottom: 2rem; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.85rem; margin-right: 1rem; }
+    nav a:hover { color: var(--accent); }
+    h2 { font-size: 1.2rem; color: var(--accent); border-left: 3px solid var(--accent); padding-left: 0.75rem; margin: 2rem 0 1rem; }
+    ul { padding-left: 1.5rem; }
+    li { margin: 0.35rem 0; }
+    code { background: var(--code-bg); color: #79c0ff; padding: 0.15em 0.45em; border-radius: 4px; font-family: "JetBrains Mono", Consolas, monospace; font-size: 0.88em; }
+    .badge { display: inline-block; background: var(--tag-bg); border: 1px solid var(--border); border-radius: 20px; padding: 0.25em 0.75em; font-size: 0.8rem; color: var(--accent); margin: 0.25rem 0.2rem; }
+    .section { margin-bottom: 2.5rem; }
+    .warn { background: #1a1a0e; border-left: 3px solid var(--yellow); padding: 0.75rem 1rem; border-radius: 0 6px 6px 0; margin-top: 1rem; }
+    .warn li { color: #e3b341; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a href="index.html">← 목록으로</a>
+      <a href="claude_md.html">CLAUDE.md</a>
+      <a href="code_convention.html">코드 컨벤션</a>
+      <a href="workflow.html">워크플로우</a>
+      <a href="test_convention.html">테스트 컨벤션</a>
+    </nav>
+    <header>
+      <h1>기술 스택</h1>
+      <p>flover-be 프로젝트에서 사용하는 기술 스택 및 주의사항</p>
+    </header>
+    <div class="section">
+      <h2>Core</h2>
+      <span class="badge">Java 21</span>
+      <span class="badge">Spring Boot 4.0.5</span>
+      <span class="badge">Spring Data JPA</span>
+      <span class="badge">Spring Web MVC</span>
+      <span class="badge">MySQL</span>
+      <span class="badge">Lombok</span>
+      <span class="badge">Gradle (Groovy DSL)</span>
+      <span class="badge">AWS SDK v2</span>
+      <ul style="margin-top:1rem;">
+        <li><code>software.amazon.awssdk:s3</code> — S3 파일 저장, Presigned URL 발급</li>
+      </ul>
+    </div>
+    <div class="section">
+      <h2>테스트</h2>
+      <span class="badge">JUnit 5</span>
+      <span class="badge">AssertJ</span>
+      <span class="badge">Mockito</span>
+      <span class="badge">Spring Boot Test</span>
+    </div>
+    <div class="section">
+      <h2>주의 사항</h2>
+      <div class="warn">
+        <ul>
+          <li><code>javax</code> 패키지 대신 <code>jakarta</code> 패키지를 사용한다.</li>
+          <li><code>@Autowired</code> 필드 주입을 사용하지 않는다. 생성자 주입만 사용한다. (Lombok <code>@RequiredArgsConstructor</code> 활용)</li>
+          <li>프로젝트에 없는 외부 라이브러리(QueryDSL, MapStruct, Security 등)는 임의로 추가하지 않는다.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/static/docs/test_convention.html
+++ b/src/main/resources/static/docs/test_convention.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>테스트 컨벤션 — flover-be</title>
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
+      --green: #3fb950; --yellow: #d29922; --red: #f85149; --purple: #bc8cff;
+      --code-bg: #1f2937; --tag-bg: #1c2a3e;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans KR, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; padding: 2rem 1rem; }
+    .container { max-width: 900px; margin: 0 auto; }
+    header { border-bottom: 1px solid var(--border); padding-bottom: 1.5rem; margin-bottom: 2rem; }
+    header h1 { font-size: 1.8rem; color: var(--accent); }
+    header p { color: var(--muted); font-size: 0.9rem; margin-top: 0.3rem; }
+    nav { margin-bottom: 2rem; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.85rem; margin-right: 1rem; }
+    nav a:hover { color: var(--accent); }
+    h2 { font-size: 1.2rem; color: var(--accent); border-left: 3px solid var(--accent); padding-left: 0.75rem; margin: 2.5rem 0 1rem; }
+    h3 { font-size: 1rem; color: var(--purple); margin: 1.25rem 0 0.6rem; }
+    ul { padding-left: 1.5rem; }
+    li { margin: 0.4rem 0; }
+    code { background: var(--code-bg); color: #79c0ff; padding: 0.15em 0.45em; border-radius: 4px; font-family: "JetBrains Mono", "Fira Code", Consolas, monospace; font-size: 0.88em; }
+    strong { color: #ffa657; }
+    pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.25rem; overflow-x: auto; margin: 0.75rem 0; font-family: "JetBrains Mono", "Fira Code", Consolas, monospace; font-size: 0.85rem; line-height: 1.6; color: #c9d1d9; }
+    pre .kw { color: #ff7b72; } pre .str { color: #a5d6ff; } pre .cmt { color: #8b949e; font-style: italic; } pre .ann { color: #d2a8ff; } pre .cls { color: #ffa657; } pre .num { color: #79c0ff; }
+    .section { margin-bottom: 2rem; }
+    .warn { background: #1a0e0e; border-left: 3px solid var(--red); padding: 0.75rem 1rem; border-radius: 0 6px 6px 0; margin-top: 0.75rem; }
+    .warn li { color: #ffa198; }
+    .warn code { background: #2a1515; color: #ff9492; }
+    .rule-list { list-style: none; padding: 0; }
+    .rule-list li { padding: 0.5rem 1rem; border-left: 2px solid var(--border); margin-bottom: 0.4rem; }
+    .compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 0.75rem; }
+    .compare-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem; }
+    .compare-card h4 { font-size: 0.9rem; margin-bottom: 0.5rem; font-family: "JetBrains Mono", Consolas, monospace; }
+    .compare-card.mock h4 { color: var(--accent); }
+    .compare-card.spy h4 { color: var(--yellow); }
+    .compare-card p { font-size: 0.88rem; color: var(--muted); line-height: 1.5; }
+    .badge-row { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.5rem; }
+    .badge { background: var(--tag-bg); border: 1px solid var(--border); border-radius: 20px; padding: 0.25em 0.75em; font-size: 0.8rem; color: var(--accent); }
+    @media (max-width: 600px) { .compare-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a href="index.html">← 목록으로</a>
+      <a href="claude_md.html">CLAUDE.md</a>
+      <a href="skills.html">기술 스택</a>
+      <a href="code_convention.html">코드 컨벤션</a>
+      <a href="workflow.html">워크플로우</a>
+    </nav>
+    <header>
+      <h1>테스트 컨벤션</h1>
+      <p>단위 테스트, 통합 테스트, 테스트 구조 및 안티패턴 가이드</p>
+    </header>
+
+    <div class="section">
+      <h2>프레임워크</h2>
+      <div class="badge-row">
+        <span class="badge">JUnit 5 + AssertJ</span>
+        <span class="badge">Mockito (단위)</span>
+        <span class="badge">@SpringBootTest (통합)</span>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>테스트 구조</h2>
+      <ul class="rule-list">
+        <li>Given-When-Then 패턴을 따른다.</li>
+        <li><code>@DisplayName</code>에 한글로 테스트 의도를 명시한다.</li>
+        <li>메서드명은 영문 snake_case로 작성한다.</li>
+      </ul>
+      <pre><span class="ann">@DisplayName</span>(<span class="str">"존재하지 않는 사용자 조회 시 예외가 발생한다"</span>)
+<span class="ann">@Test</span>
+<span class="kw">void</span> find_user_by_id_throws_exception_when_not_found() {
+    <span class="cmt">// given</span>
+    Long userId = <span class="num">999L</span>;
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    <span class="cmt">// when &amp; then</span>
+    assertThatThrownBy(() -&gt; userService.findById(userId))
+        .isInstanceOf(UserNotFoundException.<span class="kw">class</span>);
+}</pre>
+    </div>
+
+    <div class="section">
+      <h2>테스트 원칙</h2>
+      <ul class="rule-list">
+        <li>단순 비즈니스 로직 검증은 Mockito 기반 단위 테스트를 우선한다.</li>
+        <li>Repository 계층 테스트는 필요 시 <code>@DataJpaTest</code>를 우선 고려한다.</li>
+        <li>하나의 테스트는 하나의 행위/결과를 검증하는 데 집중한다.</li>
+        <li>테스트 데이터는 각 테스트 내부에서 명확하게 준비한다.</li>
+        <li>매직 넘버/하드코딩 문자열은 의미 있는 변수명으로 추출한다.</li>
+        <li>테스트 메서드에서 다른 테스트 메서드에 의존하지 않는다.</li>
+        <li>테스트 커버리지는 높게 유지하되, 수치보다 핵심 비즈니스 로직 검증을 우선한다.</li>
+        <li>의미 없는 테스트(예: Lombok 생성자, 단순 getter/setter)는 작성하지 않는다.</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>단위 테스트</h2>
+      <ul class="rule-list">
+        <li><code>@ExtendWith(MockitoExtension.class)</code> 사용</li>
+        <li>의존성은 <code>@Mock</code> / <code>@InjectMocks</code>로 주입</li>
+        <li>Service 레이어를 중점적으로 단위 테스트한다.</li>
+      </ul>
+      <h3>@Mock vs @Spy</h3>
+      <div class="compare-grid">
+        <div class="compare-card mock">
+          <h4>@Mock</h4>
+          <p>완전한 가짜 객체. 모든 메서드가 기본값(null, 0, false)을 반환하며 실제 로직은 실행되지 않는다.</p>
+          <p style="margin-top:0.5rem; color: var(--accent); font-size:0.82rem;">→ 의존성을 완전히 격리하고 싶을 때</p>
+        </div>
+        <div class="compare-card spy">
+          <h4>@Spy</h4>
+          <p>실제 객체를 감싼다. 명시적으로 stub하지 않은 메서드는 실제 구현이 그대로 실행된다.</p>
+          <p style="margin-top:0.5rem; color: var(--yellow); font-size:0.82rem;">→ 실제 동작이 필요할 때 (예: ObjectMapper)</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>통합 테스트</h2>
+      <ul class="rule-list">
+        <li><code>@SpringBootTest</code> + <code>@Transactional</code> 조합으로 DB 롤백을 보장한다.</li>
+        <li>테스트용 프로퍼티는 <code>src/test/resources/application.properties</code>에 분리한다.</li>
+        <li>통합 테스트가 꼭 필요한 경우에만 <code>@SpringBootTest</code>를 사용한다.</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>안티패턴 금지</h2>
+      <div class="warn">
+        <ul>
+          <li>프로덕션 코드를 테스트만을 위해 수정하지 않는다.</li>
+          <li><code>@Autowired</code>로 구체 구현체를 직접 주입해 결합도를 높이지 않는다.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/static/docs/workflow.html
+++ b/src/main/resources/static/docs/workflow.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>개발 워크플로우 — flover-be</title>
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
+      --green: #3fb950; --yellow: #d29922; --code-bg: #1f2937; --tag-bg: #1c2a3e;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans KR, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; padding: 2rem 1rem; }
+    .container { max-width: 860px; margin: 0 auto; }
+    header { border-bottom: 1px solid var(--border); padding-bottom: 1.5rem; margin-bottom: 2rem; }
+    header h1 { font-size: 1.8rem; color: var(--accent); }
+    header p { color: var(--muted); font-size: 0.9rem; margin-top: 0.3rem; }
+    nav { margin-bottom: 2rem; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.85rem; margin-right: 1rem; }
+    nav a:hover { color: var(--accent); }
+    h2 { font-size: 1.2rem; color: var(--accent); border-left: 3px solid var(--accent); padding-left: 0.75rem; margin: 2rem 0 1rem; }
+    code { background: var(--code-bg); color: #79c0ff; padding: 0.15em 0.45em; border-radius: 4px; font-family: "JetBrains Mono", Consolas, monospace; font-size: 0.88em; }
+    .section { margin-bottom: 2.5rem; }
+    .step-list { list-style: none; padding: 0; counter-reset: step; }
+    .step-list li { counter-increment: step; display: flex; align-items: flex-start; gap: 1rem; padding: 0.75rem 1rem; border: 1px solid var(--border); border-radius: 8px; margin-bottom: 0.5rem; background: var(--surface); }
+    .step-list li::before { content: counter(step); background: var(--accent); color: #0d1117; font-weight: 700; font-size: 0.8rem; min-width: 1.6rem; height: 1.6rem; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 0.1rem; }
+    .rule-list { list-style: none; padding: 0; }
+    .rule-list li { padding: 0.6rem 1rem; border-left: 2px solid var(--border); margin-bottom: 0.5rem; }
+    .example-box { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.25rem; margin-top: 0.75rem; }
+    .example-box .label { font-size: 0.75rem; color: var(--muted); display: block; margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    .example-box code { background: none; padding: 0; font-size: 0.9rem; color: var(--green); }
+    .prefix-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.5rem; }
+    .prefix-tag { background: var(--tag-bg); border: 1px solid var(--border); border-radius: 6px; padding: 0.3em 0.8em; font-family: "JetBrains Mono", Consolas, monospace; font-size: 0.85rem; color: var(--green); }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a href="index.html">← 목록으로</a>
+      <a href="claude_md.html">CLAUDE.md</a>
+      <a href="skills.html">기술 스택</a>
+      <a href="code_convention.html">코드 컨벤션</a>
+      <a href="test_convention.html">테스트 컨벤션</a>
+    </nav>
+    <header>
+      <h1>개발 워크플로우</h1>
+      <p>브랜치 전략, 커밋 메시지, PR 규칙 등 개발 프로세스 가이드</p>
+    </header>
+    <div class="section">
+      <h2>기능 개발 순서</h2>
+      <ol class="step-list">
+        <li>Domain Entity 정의 <code>domain/</code></li>
+        <li>Repository 인터페이스 작성 <code>repository/</code></li>
+        <li>Service 레이어 구현 <code>service/</code></li>
+        <li>DTO 작성 <code>dto/</code> — Record 사용</li>
+        <li>Controller 구현 <code>controller/</code></li>
+        <li>테스트 코드 작성 (단위 테스트 → 통합 테스트)</li>
+      </ol>
+    </div>
+    <div class="section">
+      <h2>브랜치 전략</h2>
+      <ul class="rule-list">
+        <li><code>feature/{도메인}/{기능명}</code> 형식으로 브랜치를 생성한다.</li>
+      </ul>
+      <div class="example-box">
+        <span class="label">예시</span>
+        <code>feature/user/signup</code><br/>
+        <code>feature/order/create</code>
+      </div>
+    </div>
+    <div class="section">
+      <h2>커밋 메시지</h2>
+      <ul class="rule-list">
+        <li>Conventional Commits를 따른다.</li>
+        <li>형식: <code>[type]: 한글 설명</code></li>
+      </ul>
+      <div class="prefix-grid" style="margin-top:0.75rem;">
+        <span class="prefix-tag">feat</span>
+        <span class="prefix-tag">fix</span>
+        <span class="prefix-tag">refactor</span>
+        <span class="prefix-tag">test</span>
+        <span class="prefix-tag">docs</span>
+        <span class="prefix-tag">chore</span>
+      </div>
+      <div class="example-box" style="margin-top:0.75rem;">
+        <span class="label">예시</span>
+        <code>[feat]: 회원 가입 API 구현</code><br/>
+        <code>[fix]: 주문 조회 NPE 수정</code>
+      </div>
+    </div>
+    <div class="section">
+      <h2>PR 규칙</h2>
+      <ul class="rule-list">
+        <li>PR 제목은 커밋 메시지 형식을 따른다.</li>
+        <li>관련 이슈를 반드시 연결한다 (<code>close #이슈번호</code>).</li>
+        <li>로컬 동작 확인 및 테스트 통과 후 PR을 올린다.</li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## 관련 이슈
- close #49 

## 작업 내용
- Markdown보다 HTML이 정보 전달력이 높다는 관점에서, `.ai/` 폴더의 가이드 문서를 HTML로 변환
- `src/main/resources/static/docs/`에 정적 리소스로 배치해 Spring Boot 실행 시 `/docs/index.html`로 바로 접근 가능
- 변환 대상: `CLAUDE.md`, `skills.md`, `code_convention.md`, `workflow.md`, `test_convention.md` (총 6개 페이지)
- 다크 테마, 문법 하이라이팅, 페이지 간 네비게이션 적용

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.