### PR TITLE
[feat]: 애플 OAuth 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           EC2_HOST: ${{ secrets.EC2_HOST }}
           EC2_USER: ${{ secrets.EC2_USER }}
           EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+          APPLE_CLIENT_ID: ${{ secrets.APPLE_CLIENT_ID }}
         run: |
           MISSING=()
           for VAR in DOCKER_HUB_USERNAME DOCKER_HUB_TOKEN DB_USERNAME DB_PASSWORD \

--- a/src/main/java/com/flover/flover_be/global/config/AppleProperties.java
+++ b/src/main/java/com/flover/flover_be/global/config/AppleProperties.java
@@ -1,0 +1,7 @@
+package com.flover.flover_be.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "apple")
+public record AppleProperties(String clientId) {
+}

--- a/src/main/java/com/flover/flover_be/user/controller/AuthController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController {
     public ResponseEntity<AuthDto.LoginResponse> appleLogin(
             @RequestBody @Valid AppleDto.LoginRequest request
     ) {
-        AuthDto.LoginResponse response = appleAuthService.appleLogin(request.identityToken(), request.name());
+        AuthDto.LoginResponse response = appleAuthService.appleLogin(request.identityToken());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/flover/flover_be/user/controller/AuthController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.flover.flover_be.user.controller;
 
+import com.flover.flover_be.user.dto.AppleDto;
 import com.flover.flover_be.user.dto.AuthDto;
+import com.flover.flover_be.user.service.AppleAuthService;
 import com.flover.flover_be.user.service.KakaoAuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,13 +14,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Auth", description = "카카오 OAuth 인증 API")
+@Tag(name = "Auth", description = "소셜 OAuth 인증 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final KakaoAuthService kakaoAuthService;
+    private final AppleAuthService appleAuthService;
 
     @Operation(summary = "카카오 로그인", description = "프론트에서 받은 인가 코드로 JWT 토큰 발급")
     @PostMapping("/kakao/login")
@@ -26,6 +29,15 @@ public class AuthController {
             @RequestBody @Valid AuthDto.CallbackRequest request
     ) {
         AuthDto.LoginResponse response = kakaoAuthService.kakaoLogin(request.code());
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "애플 로그인", description = "iOS 앱에서 받은 identityToken으로 JWT 토큰 발급")
+    @PostMapping("/apple/login")
+    public ResponseEntity<AuthDto.LoginResponse> appleLogin(
+            @RequestBody @Valid AppleDto.LoginRequest request
+    ) {
+        AuthDto.LoginResponse response = appleAuthService.appleLogin(request.identityToken(), request.name());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/flover/flover_be/user/domain/OAuthProvider.java
+++ b/src/main/java/com/flover/flover_be/user/domain/OAuthProvider.java
@@ -1,0 +1,5 @@
+package com.flover.flover_be.user.domain;
+
+public enum OAuthProvider {
+    KAKAO, APPLE, GOOGLE
+}

--- a/src/main/java/com/flover/flover_be/user/domain/User.java
+++ b/src/main/java/com/flover/flover_be/user/domain/User.java
@@ -11,21 +11,25 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "users")
+@Table(name = "users", uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
-    private static final long EXP_GRANT_INTERVAL_SECONDS = 5L;  // 5초마다 EXP 1 부여
+    private static final long EXP_GRANT_INTERVAL_SECONDS = 5L;
     private static final long EXP_PER_INTERVAL = 1L;
-    private static final long EXPERIENCE_PER_LEVEL = 720L;       // 1시간 플로깅 시 레벨업
+    private static final long EXPERIENCE_PER_LEVEL = 720L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "kakao_id", unique = true, nullable = false)
-    private Long kakaoId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, length = 20)
+    private OAuthProvider provider;
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
 
     private String email;
     private String nickname;
@@ -50,9 +54,10 @@ public class User {
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
-    public static User create(Long kakaoId, String email, String nickname, String profileImageUrl) {
+    public static User create(OAuthProvider provider, String providerId, String email, String nickname, String profileImageUrl) {
         User user = new User();
-        user.kakaoId = kakaoId;
+        user.provider = provider;
+        user.providerId = providerId;
         user.email = email;
         user.nickname = nickname;
         user.profileImageUrl = profileImageUrl;

--- a/src/main/java/com/flover/flover_be/user/dto/AppleDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/AppleDto.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class AppleDto {
 
-    public record LoginRequest(@NotBlank String identityToken, String name) {}
+    public record LoginRequest(@NotBlank String identityToken) {}
 
     public record JwksResponse(List<JwksKey> keys) {}
 

--- a/src/main/java/com/flover/flover_be/user/dto/AppleDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/AppleDto.java
@@ -1,0 +1,14 @@
+package com.flover.flover_be.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public class AppleDto {
+
+    public record LoginRequest(@NotBlank String identityToken, String name) {}
+
+    public record JwksResponse(List<JwksKey> keys) {}
+
+    public record JwksKey(String kty, String kid, String use, String alg, String n, String e) {}
+}

--- a/src/main/java/com/flover/flover_be/user/exception/AppleAuthException.java
+++ b/src/main/java/com/flover/flover_be/user/exception/AppleAuthException.java
@@ -1,0 +1,11 @@
+package com.flover.flover_be.user.exception;
+
+import com.flover.flover_be.global.exception.ErrorCode;
+import com.flover.flover_be.global.exception.BusinessException;
+
+public class AppleAuthException extends BusinessException {
+
+    public AppleAuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/exception/AuthErrorCode.java
+++ b/src/main/java/com/flover/flover_be/user/exception/AuthErrorCode.java
@@ -10,7 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ErrorCode {
 
     KAKAO_TOKEN_FAILED(HttpStatus.UNAUTHORIZED, "카카오 토큰 발급에 실패했습니다."),
-    KAKAO_USER_INFO_FAILED(HttpStatus.UNAUTHORIZED, "카카오 사용자 정보 조회에 실패했습니다.");
+    KAKAO_USER_INFO_FAILED(HttpStatus.UNAUTHORIZED, "카카오 사용자 정보 조회에 실패했습니다."),
+
+    APPLE_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Apple 토큰 검증에 실패했습니다."),
+    APPLE_CLAIMS_INVALID(HttpStatus.UNAUTHORIZED, "Apple 토큰의 정보가 올바르지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/flover/flover_be/user/repository/UserRepository.java
+++ b/src/main/java/com/flover/flover_be/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.flover.flover_be.user.repository;
 
+import com.flover.flover_be.user.domain.OAuthProvider;
 import com.flover.flover_be.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,7 +8,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByKakaoId(Long kakaoId);
+    Optional<User> findByProviderAndProviderId(OAuthProvider provider, String providerId);
 
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/flover/flover_be/user/service/AppleAuthService.java
+++ b/src/main/java/com/flover/flover_be/user/service/AppleAuthService.java
@@ -1,0 +1,156 @@
+package com.flover.flover_be.user.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flover.flover_be.global.config.AppleProperties;
+import com.flover.flover_be.global.jwt.JwtProvider;
+import com.flover.flover_be.user.domain.OAuthProvider;
+import com.flover.flover_be.user.domain.User;
+import com.flover.flover_be.user.dto.AppleDto;
+import com.flover.flover_be.user.dto.AuthDto;
+import com.flover.flover_be.user.exception.AppleAuthException;
+import com.flover.flover_be.user.exception.AuthErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleAuthService {
+
+    private static final String APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys";
+    private static final String APPLE_ISS = "https://appleid.apple.com";
+
+    private final UserService userService;
+    private final JwtProvider jwtProvider;
+    private final RestClient restClient;
+    private final AppleProperties appleProperties;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public AuthDto.LoginResponse appleLogin(String identityToken, String name) {
+        Claims claims = verifyIdentityToken(identityToken);
+        String appleId = claims.getSubject();
+        String email = claims.get("email", String.class);
+
+        User user = userService.upsertOAuthUser(OAuthProvider.APPLE, appleId, email);
+        String jwtToken = jwtProvider.generateToken(user.getId());
+
+        return new AuthDto.LoginResponse(jwtToken, "Bearer", user.getId(), user.getNickname(),
+                user.getEmail());
+    }
+
+    private Claims verifyIdentityToken(String identityToken) {
+        String kid = extractKid(identityToken);
+        PublicKey publicKey = fetchApplePublicKey(kid);
+
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(publicKey)
+                    .build()
+                    .parseSignedClaims(identityToken)
+                    .getPayload();
+
+            validateClaims(claims);
+            return claims;
+        } catch (AppleAuthException e) {
+            throw e;
+        } catch (JwtException e) {
+            log.error("Apple identityToken 서명 검증 실패: {}", e.getMessage());
+            throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
+        } catch (Exception e) {
+            log.error("Apple identityToken 처리 중 오류: {}", e.getMessage());
+            throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
+        }
+    }
+
+    private String extractKid(String identityToken) {
+        try {
+            String[] parts = identityToken.split("\\.");
+            byte[] headerBytes = Base64.getUrlDecoder().decode(parts[0]);
+            JsonNode header = objectMapper.readTree(headerBytes);
+            String kid = header.path("kid").asText(null);
+            if (kid == null) {
+                throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
+            }
+            return kid;
+        } catch (AppleAuthException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
+        }
+    }
+
+    private PublicKey fetchApplePublicKey(String kid) {
+        AppleDto.JwksResponse jwks;
+        try {
+            jwks = restClient.get()
+                    .uri(APPLE_JWKS_URL)
+                    .retrieve()
+                    .body(AppleDto.JwksResponse.class);
+        } catch (RestClientException e) {
+            log.error("Apple JWKS 조회 실패: {}", e.getMessage());
+            throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
+        }
+
+        if (jwks == null) {
+            throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
+        }
+
+        AppleDto.JwksKey matchedKey = jwks.keys().stream()
+                .filter(key -> kid.equals(key.kid()))
+                .findFirst()
+                .orElseThrow(() -> new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN));
+
+        return buildRsaPublicKey(matchedKey);
+    }
+
+    private PublicKey buildRsaPublicKey(AppleDto.JwksKey key) {
+        try {
+            byte[] nBytes = Base64.getUrlDecoder().decode(key.n());
+            byte[] eBytes = Base64.getUrlDecoder().decode(key.e());
+            RSAPublicKeySpec spec = new RSAPublicKeySpec(
+                    new BigInteger(1, nBytes),
+                    new BigInteger(1, eBytes)
+            );
+            return KeyFactory.getInstance("RSA").generatePublic(spec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            log.error("Apple RSA 공개키 생성 실패: {}", e.getMessage());
+            throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
+        }
+    }
+
+    private void validateClaims(Claims claims) {
+        String iss = claims.getIssuer();
+        Set<String> audience = claims.getAudience();
+        String sub = claims.getSubject();
+        log.debug("[Apple] iss={}, aud={}, sub={}", iss, audience, sub);
+
+        if (!APPLE_ISS.equals(iss)) {
+            log.error("[Apple] iss 불일치 — 실제: {}, 기대: {}", iss, APPLE_ISS);
+            throw new AppleAuthException(AuthErrorCode.APPLE_CLAIMS_INVALID);
+        }
+
+        String expectedClientId = appleProperties.clientId();
+        if (audience == null || !audience.contains(expectedClientId)) {
+            log.error("[Apple] aud 불일치 — 실제: {}, 기대: {}", audience, expectedClientId);
+            throw new AppleAuthException(AuthErrorCode.APPLE_CLAIMS_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/flover/flover_be/user/service/AppleAuthService.java
+++ b/src/main/java/com/flover/flover_be/user/service/AppleAuthService.java
@@ -44,7 +44,7 @@ public class AppleAuthService {
     private final ObjectMapper objectMapper;
 
     @Transactional
-    public AuthDto.LoginResponse appleLogin(String identityToken, String name) {
+    public AuthDto.LoginResponse appleLogin(String identityToken) {
         Claims claims = verifyIdentityToken(identityToken);
         String appleId = claims.getSubject();
         String email = claims.get("email", String.class);

--- a/src/main/java/com/flover/flover_be/user/service/KakaoAuthService.java
+++ b/src/main/java/com/flover/flover_be/user/service/KakaoAuthService.java
@@ -2,12 +2,12 @@ package com.flover.flover_be.user.service;
 
 import com.flover.flover_be.global.config.KakaoProperties;
 import com.flover.flover_be.global.jwt.JwtProvider;
+import com.flover.flover_be.user.domain.OAuthProvider;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.dto.AuthDto;
 import com.flover.flover_be.user.dto.KakaoDto;
 import com.flover.flover_be.user.exception.AuthErrorCode;
 import com.flover.flover_be.user.exception.KakaoAuthException;
-import com.flover.flover_be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -19,8 +19,6 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 
-import java.util.concurrent.ThreadLocalRandom;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -29,7 +27,7 @@ public class KakaoAuthService {
     private static final String KAKAO_AUTH_URL = "https://kauth.kakao.com";
     private static final String KAKAO_API_URL = "https://kapi.kakao.com";
 
-    private final UserRepository userRepository;
+    private final UserService userService;
     private final JwtProvider jwtProvider;
     private final RestClient restClient;
     private final KakaoProperties kakaoProperties;
@@ -93,20 +91,6 @@ public class KakaoAuthService {
     private User upsertUser(KakaoDto.UserInfoResponse userInfo) {
         KakaoDto.UserInfoResponse.KakaoAccount account = userInfo.kakaoAccount();
         String email = account != null ? account.email() : null;
-
-        return userRepository.findByKakaoId(userInfo.id())
-                .orElseGet(() -> {
-                    String defaultNickname = generateDefaultNickname();
-                    return userRepository.save(User.create(userInfo.id(), email, defaultNickname, null));
-                });
-    }
-
-    private String generateDefaultNickname() {
-        String nickname;
-        do {
-            int suffix = ThreadLocalRandom.current().nextInt(100000, 1000000);
-            nickname = "플러버" + suffix;
-        } while (userRepository.existsByNickname(nickname));
-        return nickname;
+        return userService.upsertOAuthUser(OAuthProvider.KAKAO, String.valueOf(userInfo.id()), email);
     }
 }

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.flover.flover_be.user.service;
 
 import com.flover.flover_be.global.storage.StorageDto;
 import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
+import com.flover.flover_be.user.domain.OAuthProvider;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.dto.UserDto;
 import com.flover.flover_be.user.exception.UserErrorCode;
@@ -10,6 +11,8 @@ import com.flover.flover_be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.ThreadLocalRandom;
 
 @Service
 @RequiredArgsConstructor
@@ -58,6 +61,24 @@ public class UserService {
         }
         user.updateProfileImage(imageUrl);
         return new UserDto.ProfileImageResponse(user.getId(), user.getProfileImageUrl());
+    }
+
+    @Transactional
+    public User upsertOAuthUser(OAuthProvider provider, String providerId, String email) {
+        return userRepository.findByProviderAndProviderId(provider, providerId)
+                .orElseGet(() -> {
+                    String nickname = generateDefaultNickname();
+                    return userRepository.save(User.create(provider, providerId, email, nickname, null));
+                });
+    }
+
+    private String generateDefaultNickname() {
+        String nickname;
+        do {
+            int suffix = ThreadLocalRandom.current().nextInt(100000, 1000000);
+            nickname = "플러버" + suffix;
+        } while (userRepository.existsByNickname(nickname));
+        return nickname;
     }
 
     private User getUserOrThrow(Long userId) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,9 @@ kakao.client-id=${KAKAO_CLIENT_ID}
 kakao.client-secret=${KAKAO_CLIENT_SECRET}
 kakao.redirect-uri=${KAKAO_REDIRECT_URI}
 
+# Apple OAuth
+apple.client-id=${APPLE_CLIENT_ID}
+
 # JWT
 jwt.secret=${JWT_SECRET}
 jwt.expiration=${JWT_EXPIRATION}

--- a/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
@@ -9,6 +9,7 @@ import com.flover.flover_be.plogging.exception.PloggingException;
 import com.flover.flover_be.plogging.repository.PloggingPhotoRepository;
 import com.flover.flover_be.plogging.repository.PloggingRoutePointRepository;
 import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
+import com.flover.flover_be.user.domain.OAuthProvider;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.exception.UserException;
 import com.flover.flover_be.user.repository.UserRepository;
@@ -50,7 +51,7 @@ class PloggingServiceTest {
     void complete_성공() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         PloggingDto.CompleteRequest request = buildRequest(List.of(
                 new PloggingDto.RoutePointRequest(37.1, 127.1),
                 new PloggingDto.RoutePointRequest(37.2, 127.2)
@@ -87,7 +88,7 @@ class PloggingServiceTest {
     void complete_경로포인트_시퀀스_부여() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         List<PloggingDto.RoutePointRequest> routePoints = List.of(
                 new PloggingDto.RoutePointRequest(37.1, 127.1),
                 new PloggingDto.RoutePointRequest(37.2, 127.2),
@@ -121,7 +122,7 @@ class PloggingServiceTest {
     void complete_사진_시퀀스_부여() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         List<String> photoUrls = List.of(
                 "https://s3.example.com/photo0.jpg",
                 "https://s3.example.com/photo1.jpg"
@@ -151,7 +152,7 @@ class PloggingServiceTest {
     void complete_유저_플로깅시간_갱신() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         int ploggingSeconds = 600;
         PloggingDto.CompleteRequest request = buildRequest(List.of(), List.of());
 
@@ -172,7 +173,7 @@ class PloggingServiceTest {
     void complete_빈_목록_성공() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         PloggingDto.CompleteRequest request = buildRequest(List.of(), List.of());
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
@@ -196,7 +197,7 @@ class PloggingServiceTest {
         Long userId = 1L;
         Pageable pageable = PageRequest.of(0, 20);
         LocalDateTime now = LocalDateTime.of(2026, 5, 4, 10, 0, 0);
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
 
         PloggingSession older = PloggingSession.create(
                 user, PloggingMode.FREE,
@@ -230,7 +231,7 @@ class PloggingServiceTest {
         // given
         Long userId = 1L;
         Pageable pageable = PageRequest.of(0, 1);
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         PloggingSession session = PloggingSession.create(
                 user, PloggingMode.FREE,
                 LocalDateTime.now(), LocalDateTime.now().plusHours(1),
@@ -266,7 +267,7 @@ class PloggingServiceTest {
         // given
         Long userId = 1L;
         Pageable pageable = PageRequest.of(0, 20);
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(ploggingSessionRepository.findAllByUserIdOrderByStartedAtDesc(userId, pageable))
                 .willReturn(new SliceImpl<>(List.of(), pageable, false));
@@ -287,7 +288,7 @@ class PloggingServiceTest {
         Long sessionId = 10L;
         LocalDateTime startedAt = LocalDateTime.of(2026, 5, 4, 10, 0, 0);
         LocalDateTime finishedAt = LocalDateTime.of(2026, 5, 4, 10, 30, 0);
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
 
         PloggingSession session = PloggingSession.create(
                 user, PloggingMode.FREE,
@@ -331,7 +332,7 @@ class PloggingServiceTest {
         // given
         Long userId = 1L;
         Long sessionId = 999L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(ploggingSessionRepository.findByIdAndUserId(sessionId, userId)).willReturn(Optional.empty());
 
@@ -346,7 +347,7 @@ class PloggingServiceTest {
         // given
         Long userId = 1L;
         Long sessionId = 10L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         PloggingSession session = PloggingSession.create(
                 user, PloggingMode.FREE,
                 LocalDateTime.of(2026, 5, 4, 9, 0, 0), LocalDateTime.of(2026, 5, 4, 9, 30, 0),
@@ -378,7 +379,7 @@ class PloggingServiceTest {
     void find_monthly_stats_성공() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         List<PloggingSessionRepository.SessionStatsView> sessions = List.of(
                 mockSessionStats(LocalDateTime.of(2026, 4, 10, 9, 0), 4000, 3000, 150, 1800),
                 mockSessionStats(LocalDateTime.of(2026, 4, 20, 9, 0), 5000, 4000, 200, 2400)
@@ -407,7 +408,7 @@ class PloggingServiceTest {
     void find_monthly_stats_기록없음_모두_0() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(ploggingSessionRepository.findSessionStatsInPeriod(
@@ -441,7 +442,7 @@ class PloggingServiceTest {
     void find_weekly_stats_7개_날짜_반환() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         LocalDate startDate = LocalDate.of(2026, 4, 14);
         List<PloggingSessionRepository.SessionStatsView> sessions = List.of(
                 mockSessionStats(LocalDateTime.of(2026, 4, 15, 9, 0), 4800, 3900, 220, 3600)
@@ -467,7 +468,7 @@ class PloggingServiceTest {
     void find_weekly_stats_기록없는_날_0으로_채워짐() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
         LocalDate startDate = LocalDate.of(2026, 4, 14);
         List<PloggingSessionRepository.SessionStatsView> sessions = List.of(
                 mockSessionStats(LocalDateTime.of(2026, 4, 15, 9, 0), 4800, 3900, 220, 3600)

--- a/src/test/java/com/flover/flover_be/user/domain/UserTest.java
+++ b/src/test/java/com/flover/flover_be/user/domain/UserTest.java
@@ -1,22 +1,25 @@
 package com.flover.flover_be.user.domain;
 
+import com.flover.flover_be.user.exception.UserException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import com.flover.flover_be.user.exception.UserException;
-import com.flover.flover_be.user.domain.UserTitle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UserTest {
 
-    @DisplayName("User.create initializes fields")
+    private static User kakaoUser(String nickname) {
+        return User.create(OAuthProvider.KAKAO, "12345", "test@test.com", nickname, null);
+    }
+
+    @DisplayName("User.create 시 provider, providerId를 포함한 필드가 초기화된다")
     @Test
     void create_initializes_fields() {
-        User user = User.create(12345L, "test@test.com", "nickname", "http://img.url");
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "nickname", "http://img.url");
 
-        assertThat(user.getKakaoId()).isEqualTo(12345L);
+        assertThat(user.getProvider()).isEqualTo(OAuthProvider.KAKAO);
+        assertThat(user.getProviderId()).isEqualTo("12345");
         assertThat(user.getEmail()).isEqualTo("test@test.com");
         assertThat(user.getNickname()).isEqualTo("nickname");
         assertThat(user.getProfileImageUrl()).isEqualTo("http://img.url");
@@ -26,10 +29,10 @@ class UserTest {
         assertThat(user.getTitle()).isEqualTo(UserTitle.쓰봉이);
     }
 
-    @DisplayName("Update nickname and profile image")
+    @DisplayName("닉네임과 프로필 이미지를 동시에 변경한다")
     @Test
     void updateProfile_updates_nickname_and_profile_image() {
-        User user = User.create(1L, "a@b.com", "oldNickname", "old.jpg");
+        User user = User.create(OAuthProvider.KAKAO, "1", "a@b.com", "oldNickname", "old.jpg");
 
         user.updateProfile("newNickname", "new.jpg");
 
@@ -37,20 +40,20 @@ class UserTest {
         assertThat(user.getProfileImageUrl()).isEqualTo("new.jpg");
     }
 
-    @DisplayName("Update nickname")
+    @DisplayName("닉네임을 변경한다")
     @Test
     void updateNickname_updates_nickname() {
-        User user = User.create(1L, "a@b.com", "oldNickname", null);
+        User user = User.create(OAuthProvider.KAKAO, "1", "a@b.com", "oldNickname", null);
 
         user.updateNickname("newNickname");
 
         assertThat(user.getNickname()).isEqualTo("newNickname");
     }
 
-    @DisplayName("Update profile image")
+    @DisplayName("프로필 이미지를 변경한다")
     @Test
     void updateProfileImage_updates_profile_image() {
-        User user = User.create(1L, "a@b.com", "nickname", "old.jpg");
+        User user = User.create(OAuthProvider.KAKAO, "1", "a@b.com", "nickname", "old.jpg");
 
         user.updateProfileImage("new.jpg");
 
@@ -60,22 +63,22 @@ class UserTest {
     @DisplayName("플로깅 시간(초) 추가 시 경험치, 레벨, 칭호가 갱신된다")
     @Test
     void addPloggingTimeSeconds_updates_experience_and_level() {
-        User user = User.create(1L, "a@b.com", "nickname", null);
+        User user = kakaoUser("nickname");
 
         user.addPloggingTimeSeconds(3600L); // 1시간
 
         assertThat(user.getTotalPloggingSeconds()).isEqualTo(3600L);
         assertThat(user.getExperience()).isEqualTo(720L);  // 3600 / 5 * 1
         assertThat(user.getLevel()).isEqualTo(2);           // 720 / 720 + 1
-        assertThat(user.getTitle()).isEqualTo(UserTitle.새싹_수거자); // level 2
+        assertThat(user.getTitle()).isEqualTo(UserTitle.새싹_수거자);
     }
 
     @DisplayName("5초 미만 자투리 시간은 경험치에 반영되지 않는다")
     @Test
     void addPloggingTimeSeconds_partial_interval_not_counted() {
-        User user = User.create(1L, "a@b.com", "nickname", null);
+        User user = kakaoUser("nickname");
 
-        user.addPloggingTimeSeconds(4L); // 5초 미만
+        user.addPloggingTimeSeconds(4L);
 
         assertThat(user.getExperience()).isZero();
     }
@@ -83,7 +86,7 @@ class UserTest {
     @DisplayName("5초 단위로 경험치가 정확히 반영된다")
     @Test
     void addPloggingTimeSeconds_grants_exp_every_5_seconds() {
-        User user = User.create(1L, "a@b.com", "nickname", null);
+        User user = kakaoUser("nickname");
 
         user.addPloggingTimeSeconds(5L);
         assertThat(user.getExperience()).isEqualTo(1L);
@@ -95,23 +98,22 @@ class UserTest {
     @DisplayName("레벨 기준 사이 구간에서도 현재 레벨 이하 최고 칭호가 적용된다")
     @Test
     void title_reflects_highest_applicable_for_level_in_between() {
-        User user = User.create(1L, "a@b.com", "nickname", null);
+        User user = kakaoUser("nickname");
 
-        // level 17 → 쓰줍 고수 (15레벨 기준, 20레벨 미달)
-        user.addPloggingTimeSeconds(3600L * 17); // 17시간 → level 18
-        // 17시간 = 3600 * 17 = 61200초 → EXP = 61200/5 = 12240 → level = 12240/720+1 = 18
-        // level 18 → 쓰줍 고수 (15 이상 20 미만)
+        // 17시간 → EXP=12240 → level 18 → 쓰줍 고수 (15~19레벨 구간)
+        user.addPloggingTimeSeconds(3600L * 17);
+
         assertThat(user.getTitle()).isEqualTo(UserTitle.쓰줍_고수);
     }
 
     @DisplayName("레벨 기준과 정확히 일치하면 해당 칭호가 적용된다")
     @Test
     void title_changes_exactly_at_level_threshold() {
-        User user = User.create(1L, "a@b.com", "nickname", null);
+        User user = kakaoUser("nickname");
 
-        // level 5 정확히 달성 → 쓰줍 초보자
-        // level 5 = EXP 2880 = totalSeconds 14400 (4시간)
-        user.addPloggingTimeSeconds(3600L * 4); // 4시간 → level 5
+        // 4시간 → level 5 → 쓰줍 초보자
+        user.addPloggingTimeSeconds(3600L * 4);
+
         assertThat(user.getLevel()).isEqualTo(5);
         assertThat(user.getTitle()).isEqualTo(UserTitle.쓰줍_초보자);
     }
@@ -119,7 +121,7 @@ class UserTest {
     @DisplayName("플로깅 시간이 0 이하이면 예외가 발생한다")
     @Test
     void addPloggingTimeSeconds_invalid_throws_exception() {
-        User user = User.create(1L, "a@b.com", "nickname", null);
+        User user = kakaoUser("nickname");
 
         assertThatThrownBy(() -> user.addPloggingTimeSeconds(0L))
                 .isInstanceOf(UserException.class);

--- a/src/test/java/com/flover/flover_be/user/service/AppleAuthServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/AppleAuthServiceTest.java
@@ -139,7 +139,7 @@ class AppleAuthServiceTest {
         when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
 
         // when
-        AuthDto.LoginResponse result = appleAuthService.appleLogin(validToken(), null);
+        AuthDto.LoginResponse result = appleAuthService.appleLogin(validToken());
 
         // then
         assertThat(result.accessToken()).isEqualTo("jwt-token");
@@ -164,7 +164,7 @@ class AppleAuthServiceTest {
         when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
 
         // when
-        appleAuthService.appleLogin(token, "홍길동");
+        appleAuthService.appleLogin(token);
 
         // then
         verify(userService).upsertOAuthUser(OAuthProvider.APPLE, specificAppleId, specificEmail);
@@ -183,7 +183,7 @@ class AppleAuthServiceTest {
         stubJwks();
 
         // when & then
-        assertThatThrownBy(() -> appleAuthService.appleLogin(expiredToken, null))
+        assertThatThrownBy(() -> appleAuthService.appleLogin(expiredToken))
                 .isInstanceOf(AppleAuthException.class);
     }
 
@@ -206,7 +206,7 @@ class AppleAuthServiceTest {
         when(getResponseSpec.body(AppleDto.JwksResponse.class)).thenReturn(mismatchedJwks);
 
         // when & then
-        assertThatThrownBy(() -> appleAuthService.appleLogin(validToken(), null))
+        assertThatThrownBy(() -> appleAuthService.appleLogin(validToken()))
                 .isInstanceOf(AppleAuthException.class);
     }
 
@@ -223,7 +223,7 @@ class AppleAuthServiceTest {
         stubJwks();
 
         // when & then
-        assertThatThrownBy(() -> appleAuthService.appleLogin(token, null))
+        assertThatThrownBy(() -> appleAuthService.appleLogin(token))
                 .isInstanceOf(AppleAuthException.class);
     }
 
@@ -238,7 +238,7 @@ class AppleAuthServiceTest {
         stubJwks();
 
         // when & then
-        assertThatThrownBy(() -> appleAuthService.appleLogin(token, null))
+        assertThatThrownBy(() -> appleAuthService.appleLogin(token))
                 .isInstanceOf(AppleAuthException.class);
     }
 
@@ -252,7 +252,7 @@ class AppleAuthServiceTest {
                 .thenThrow(mock(RestClientException.class));
 
         // when & then
-        assertThatThrownBy(() -> appleAuthService.appleLogin(validToken(), null))
+        assertThatThrownBy(() -> appleAuthService.appleLogin(validToken()))
                 .isInstanceOf(AppleAuthException.class);
     }
 
@@ -266,14 +266,14 @@ class AppleAuthServiceTest {
         when(getResponseSpec.body(AppleDto.JwksResponse.class)).thenReturn(noMatchJwks);
 
         // when & then
-        assertThatThrownBy(() -> appleAuthService.appleLogin(validToken(), null))
+        assertThatThrownBy(() -> appleAuthService.appleLogin(validToken()))
                 .isInstanceOf(AppleAuthException.class);
     }
 
     @DisplayName("잘못된 형식의 identityToken이면 AppleAuthException이 발생한다")
     @Test
     void 잘못된_토큰_형식_예외() {
-        assertThatThrownBy(() -> appleAuthService.appleLogin("not.a.valid.jwt.token", null))
+        assertThatThrownBy(() -> appleAuthService.appleLogin("not.a.valid.jwt.token"))
                 .isInstanceOf(AppleAuthException.class);
     }
 }

--- a/src/test/java/com/flover/flover_be/user/service/AppleAuthServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/AppleAuthServiceTest.java
@@ -1,0 +1,279 @@
+package com.flover.flover_be.user.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flover.flover_be.global.config.AppleProperties;
+import com.flover.flover_be.global.jwt.JwtProvider;
+import com.flover.flover_be.user.domain.OAuthProvider;
+import com.flover.flover_be.user.domain.User;
+import com.flover.flover_be.user.dto.AppleDto;
+import com.flover.flover_be.user.dto.AuthDto;
+import com.flover.flover_be.user.exception.AppleAuthException;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AppleAuthServiceTest {
+
+    private static final String KID = "test-kid-001";
+    private static final String APPLE_ID = "apple.user.id.00001";
+    private static final String EMAIL = "user@privaterelay.appleid.com";
+    private static final String CLIENT_ID = "com.example.plover";
+
+    private static KeyPair keyPair;
+
+    @Mock private UserService userService;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private RestClient restClient;
+    @Mock private AppleProperties appleProperties;
+    @Spy  private ObjectMapper objectMapper;
+
+    @InjectMocks private AppleAuthService appleAuthService;
+
+    private RestClient.RequestHeadersUriSpec getUriSpec;
+    private RestClient.RequestHeadersSpec getHeadersSpec;
+    private RestClient.ResponseSpec getResponseSpec;
+
+    @BeforeAll
+    static void generateKeyPair() throws NoSuchAlgorithmException {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        keyPair = generator.generateKeyPair();
+    }
+
+    @BeforeEach
+    void setUp() {
+        getUriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        getHeadersSpec = mock(RestClient.RequestHeadersSpec.class);
+        getResponseSpec = mock(RestClient.ResponseSpec.class);
+
+        when(restClient.get()).thenReturn(getUriSpec);
+        when(getUriSpec.uri(anyString())).thenReturn(getHeadersSpec);
+        when(getHeadersSpec.retrieve()).thenReturn(getResponseSpec);
+
+        when(appleProperties.clientId()).thenReturn(CLIENT_ID);
+    }
+
+    // ──────────────── helpers ────────────────
+
+    private String buildIdentityToken(String iss, String aud, String sub, String email, Date expiration) {
+        var builder = Jwts.builder()
+                .header().add("kid", KID).and()
+                .issuer(iss)
+                .subject(sub)
+                .claim("email", email)
+                .expiration(expiration)
+                .signWith(keyPair.getPrivate());
+        if (aud != null) {
+            builder.audience().add(aud);
+        }
+        return builder.compact();
+    }
+
+    private AppleDto.JwksResponse buildJwksResponse() {
+        RSAPublicKey pub = (RSAPublicKey) keyPair.getPublic();
+        byte[] nBytes = stripLeadingZero(pub.getModulus().toByteArray());
+        byte[] eBytes = stripLeadingZero(pub.getPublicExponent().toByteArray());
+        String n = Base64.getUrlEncoder().withoutPadding().encodeToString(nBytes);
+        String e = Base64.getUrlEncoder().withoutPadding().encodeToString(eBytes);
+        return new AppleDto.JwksResponse(List.of(new AppleDto.JwksKey("RSA", KID, "sig", "RS256", n, e)));
+    }
+
+    private byte[] stripLeadingZero(byte[] bytes) {
+        if (bytes.length > 1 && bytes[0] == 0) {
+            return Arrays.copyOfRange(bytes, 1, bytes.length);
+        }
+        return bytes;
+    }
+
+    private void stubJwks() {
+        when(getResponseSpec.body(AppleDto.JwksResponse.class)).thenReturn(buildJwksResponse());
+    }
+
+    private String validToken() {
+        return buildIdentityToken(
+                "https://appleid.apple.com", CLIENT_ID, APPLE_ID, EMAIL,
+                new Date(System.currentTimeMillis() + 3_600_000)
+        );
+    }
+
+    // ──────────────── 성공 케이스 ────────────────
+
+    @DisplayName("유효한 identityToken으로 로그인하면 JWT를 반환한다")
+    @Test
+    void 유효한_identityToken_로그인_성공() {
+        // given
+        User user = User.create(OAuthProvider.APPLE, APPLE_ID, EMAIL, "플러버123456", null);
+        stubJwks();
+        when(userService.upsertOAuthUser(OAuthProvider.APPLE, APPLE_ID, EMAIL)).thenReturn(user);
+        when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
+
+        // when
+        AuthDto.LoginResponse result = appleAuthService.appleLogin(validToken(), null);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo("jwt-token");
+        assertThat(result.tokenType()).isEqualTo("Bearer");
+        verify(userService).upsertOAuthUser(OAuthProvider.APPLE, APPLE_ID, EMAIL);
+    }
+
+    @DisplayName("identityToken에서 sub와 email을 추출해 upsert를 호출한다")
+    @Test
+    void identityToken_claims_추출_검증() {
+        // given
+        String specificAppleId = "apple.specific.id.99999";
+        String specificEmail = "specific@privaterelay.appleid.com";
+        String token = buildIdentityToken(
+                "https://appleid.apple.com", CLIENT_ID,
+                specificAppleId, specificEmail,
+                new Date(System.currentTimeMillis() + 3_600_000)
+        );
+        User user = User.create(OAuthProvider.APPLE, specificAppleId, specificEmail, "플러버111111", null);
+        stubJwks();
+        when(userService.upsertOAuthUser(any(), any(), any())).thenReturn(user);
+        when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
+
+        // when
+        appleAuthService.appleLogin(token, "홍길동");
+
+        // then
+        verify(userService).upsertOAuthUser(OAuthProvider.APPLE, specificAppleId, specificEmail);
+    }
+
+    // ──────────────── 토큰 검증 실패 ────────────────
+
+    @DisplayName("만료된 identityToken이면 AppleAuthException이 발생한다")
+    @Test
+    void 만료된_identityToken_예외() {
+        // given
+        String expiredToken = buildIdentityToken(
+                "https://appleid.apple.com", CLIENT_ID, APPLE_ID, EMAIL,
+                new Date(System.currentTimeMillis() - 1_000)
+        );
+        stubJwks();
+
+        // when & then
+        assertThatThrownBy(() -> appleAuthService.appleLogin(expiredToken, null))
+                .isInstanceOf(AppleAuthException.class);
+    }
+
+    @DisplayName("서명이 유효하지 않은 토큰이면 AppleAuthException이 발생한다")
+    @Test
+    void 서명_무효_토큰_예외() throws NoSuchAlgorithmException {
+        // given: validToken과 다른 키로 서명된 JWKS를 반환 → 서명 불일치
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair otherKeyPair = generator.generateKeyPair();
+
+        RSAPublicKey otherPub = (RSAPublicKey) otherKeyPair.getPublic();
+        byte[] nBytes = stripLeadingZero(otherPub.getModulus().toByteArray());
+        byte[] eBytes = stripLeadingZero(otherPub.getPublicExponent().toByteArray());
+        String n = Base64.getUrlEncoder().withoutPadding().encodeToString(nBytes);
+        String e = Base64.getUrlEncoder().withoutPadding().encodeToString(eBytes);
+        AppleDto.JwksResponse mismatchedJwks = new AppleDto.JwksResponse(
+                List.of(new AppleDto.JwksKey("RSA", KID, "sig", "RS256", n, e))
+        );
+        when(getResponseSpec.body(AppleDto.JwksResponse.class)).thenReturn(mismatchedJwks);
+
+        // when & then
+        assertThatThrownBy(() -> appleAuthService.appleLogin(validToken(), null))
+                .isInstanceOf(AppleAuthException.class);
+    }
+
+    // ──────────────── claims 검증 실패 ────────────────
+
+    @DisplayName("iss가 애플 도메인이 아니면 AppleAuthException이 발생한다")
+    @Test
+    void 잘못된_iss_예외() {
+        // given
+        String token = buildIdentityToken(
+                "https://invalid.issuer.com", CLIENT_ID, APPLE_ID, EMAIL,
+                new Date(System.currentTimeMillis() + 3_600_000)
+        );
+        stubJwks();
+
+        // when & then
+        assertThatThrownBy(() -> appleAuthService.appleLogin(token, null))
+                .isInstanceOf(AppleAuthException.class);
+    }
+
+    @DisplayName("aud가 앱 Bundle ID와 다르면 AppleAuthException이 발생한다")
+    @Test
+    void 잘못된_aud_예외() {
+        // given
+        String token = buildIdentityToken(
+                "https://appleid.apple.com", "com.other.app", APPLE_ID, EMAIL,
+                new Date(System.currentTimeMillis() + 3_600_000)
+        );
+        stubJwks();
+
+        // when & then
+        assertThatThrownBy(() -> appleAuthService.appleLogin(token, null))
+                .isInstanceOf(AppleAuthException.class);
+    }
+
+    // ──────────────── JWKS 조회 실패 ────────────────
+
+    @DisplayName("JWKS 조회에 실패하면 AppleAuthException이 발생한다")
+    @Test
+    void JWKS_조회_실패_예외() {
+        // given
+        when(getResponseSpec.body(AppleDto.JwksResponse.class))
+                .thenThrow(mock(RestClientException.class));
+
+        // when & then
+        assertThatThrownBy(() -> appleAuthService.appleLogin(validToken(), null))
+                .isInstanceOf(AppleAuthException.class);
+    }
+
+    @DisplayName("JWKS에 매칭되는 kid가 없으면 AppleAuthException이 발생한다")
+    @Test
+    void kid_매칭_없음_예외() {
+        // given
+        AppleDto.JwksResponse noMatchJwks = new AppleDto.JwksResponse(
+                List.of(new AppleDto.JwksKey("RSA", "different-kid", "sig", "RS256", "n", "e"))
+        );
+        when(getResponseSpec.body(AppleDto.JwksResponse.class)).thenReturn(noMatchJwks);
+
+        // when & then
+        assertThatThrownBy(() -> appleAuthService.appleLogin(validToken(), null))
+                .isInstanceOf(AppleAuthException.class);
+    }
+
+    @DisplayName("잘못된 형식의 identityToken이면 AppleAuthException이 발생한다")
+    @Test
+    void 잘못된_토큰_형식_예외() {
+        assertThatThrownBy(() -> appleAuthService.appleLogin("not.a.valid.jwt.token", null))
+                .isInstanceOf(AppleAuthException.class);
+    }
+}

--- a/src/test/java/com/flover/flover_be/user/service/KakaoAuthServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/KakaoAuthServiceTest.java
@@ -2,12 +2,13 @@ package com.flover.flover_be.user.service;
 
 import com.flover.flover_be.global.config.KakaoProperties;
 import com.flover.flover_be.global.jwt.JwtProvider;
+import com.flover.flover_be.user.domain.OAuthProvider;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.dto.AuthDto;
 import com.flover.flover_be.user.dto.KakaoDto;
 import com.flover.flover_be.user.exception.KakaoAuthException;
-import com.flover.flover_be.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,13 +19,14 @@ import org.mockito.quality.Strictness;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
-import org.mockito.ArgumentCaptor;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 @ExtendWith(MockitoExtension.class)
@@ -32,12 +34,11 @@ import static org.mockito.Mockito.*;
 class KakaoAuthServiceTest {
 
     @Mock private RestClient restClient;
-    @Mock private UserRepository userRepository;
+    @Mock private UserService userService;
     @Mock private JwtProvider jwtProvider;
     @Mock private KakaoProperties kakaoProperties;
 
-    @InjectMocks
-    private KakaoAuthService kakaoAuthService;
+    @InjectMocks private KakaoAuthService kakaoAuthService;
 
     private RestClient.RequestBodyUriSpec postUriSpec;
     private RestClient.RequestBodySpec postBodySpec;
@@ -69,84 +70,74 @@ class KakaoAuthServiceTest {
         when(getHeadersSpec.retrieve()).thenReturn(getResponseSpec);
     }
 
-    private KakaoDto.UserInfoResponse buildUserInfo(Long id, String email, String nickname) {
-        var profile = new KakaoDto.UserInfoResponse.KakaoAccount.Profile(nickname, "http://img.url");
+    private KakaoDto.UserInfoResponse buildUserInfo(Long id, String email) {
+        var profile = new KakaoDto.UserInfoResponse.KakaoAccount.Profile("홍길동", "http://img.url");
         var account = new KakaoDto.UserInfoResponse.KakaoAccount(email, profile);
         return new KakaoDto.UserInfoResponse(id, account);
     }
 
-    @Test
-    void 신규_유저면_save_호출() {
-        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com", "홍길동");
-        User saved = User.create(999L, "user@test.com", "플러버123456", null);
-
+    private void stubKakaoApi(KakaoDto.UserInfoResponse userInfo) {
         when(postResponseSpec.body(KakaoDto.TokenResponse.class))
                 .thenReturn(new KakaoDto.TokenResponse("kakao-token", "Bearer", "refresh", 3600L));
         when(getResponseSpec.body(KakaoDto.UserInfoResponse.class)).thenReturn(userInfo);
-        when(userRepository.findByKakaoId(999L)).thenReturn(Optional.empty());
-        when(userRepository.existsByNickname(anyString())).thenReturn(false);
-        when(userRepository.save(any(User.class))).thenReturn(saved);
+    }
+
+    @DisplayName("카카오 로그인 성공 시 JWT를 반환한다")
+    @Test
+    void 카카오_로그인_성공() {
+        // given
+        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com");
+        User user = User.create(OAuthProvider.KAKAO, "999", "user@test.com", "플러버123456", null);
+
+        stubKakaoApi(userInfo);
+        when(userService.upsertOAuthUser(OAuthProvider.KAKAO, "999", "user@test.com")).thenReturn(user);
         when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
 
+        // when
         AuthDto.LoginResponse result = kakaoAuthService.kakaoLogin("auth-code");
 
+        // then
         assertThat(result.accessToken()).isEqualTo("jwt-token");
-        verify(userRepository).save(any(User.class));
+        assertThat(result.tokenType()).isEqualTo("Bearer");
     }
 
+    @DisplayName("카카오 로그인 시 provider=KAKAO, providerId=카카오ID(String)로 upsert를 호출한다")
     @Test
-    void 신규_유저_기본_닉네임이_플러버_형식으로_생성됨() {
-        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com", "홍길동");
+    void 카카오_upsert_인자_검증() {
+        // given
+        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com");
+        User user = User.create(OAuthProvider.KAKAO, "999", "user@test.com", "플러버123456", null);
 
-        when(postResponseSpec.body(KakaoDto.TokenResponse.class))
-                .thenReturn(new KakaoDto.TokenResponse("kakao-token", "Bearer", "refresh", 3600L));
-        when(getResponseSpec.body(KakaoDto.UserInfoResponse.class)).thenReturn(userInfo);
-        when(userRepository.findByKakaoId(999L)).thenReturn(Optional.empty());
-        when(userRepository.existsByNickname(anyString())).thenReturn(false);
-        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        stubKakaoApi(userInfo);
+        when(userService.upsertOAuthUser(any(), any(), any())).thenReturn(user);
         when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
 
+        // when
         kakaoAuthService.kakaoLogin("auth-code");
 
-        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
-        verify(userRepository).save(captor.capture());
-        assertThat(captor.getValue().getNickname()).matches("플러버\\d{6}");
+        // then
+        verify(userService).upsertOAuthUser(OAuthProvider.KAKAO, "999", "user@test.com");
     }
 
+    @DisplayName("카카오 계정에 이메일이 없으면 null로 upsert를 호출한다")
     @Test
-    void 닉네임_중복시_재생성() {
-        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com", "홍길동");
+    void 이메일_없는_카카오_계정_upsert() {
+        // given
+        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, null);
+        User user = User.create(OAuthProvider.KAKAO, "999", null, "플러버123456", null);
 
-        when(postResponseSpec.body(KakaoDto.TokenResponse.class))
-                .thenReturn(new KakaoDto.TokenResponse("kakao-token", "Bearer", "refresh", 3600L));
-        when(getResponseSpec.body(KakaoDto.UserInfoResponse.class)).thenReturn(userInfo);
-        when(userRepository.findByKakaoId(999L)).thenReturn(Optional.empty());
-        when(userRepository.existsByNickname(anyString())).thenReturn(true).thenReturn(false);
-        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        stubKakaoApi(userInfo);
+        when(userService.upsertOAuthUser(any(), any(), any())).thenReturn(user);
         when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
 
+        // when
         kakaoAuthService.kakaoLogin("auth-code");
 
-        verify(userRepository, times(2)).existsByNickname(anyString());
+        // then
+        verify(userService).upsertOAuthUser(OAuthProvider.KAKAO, "999", null);
     }
 
-    @Test
-    void 기존_유저면_save_호출_안하고_닉네임_유지() {
-        KakaoDto.UserInfoResponse userInfo = buildUserInfo(999L, "user@test.com", "새닉네임");
-        User existing = User.create(999L, "user@test.com", "기존닉네임", "old.jpg");
-
-        when(postResponseSpec.body(KakaoDto.TokenResponse.class))
-                .thenReturn(new KakaoDto.TokenResponse("kakao-token", "Bearer", "refresh", 3600L));
-        when(getResponseSpec.body(KakaoDto.UserInfoResponse.class)).thenReturn(userInfo);
-        when(userRepository.findByKakaoId(999L)).thenReturn(Optional.of(existing));
-        when(jwtProvider.generateToken(any())).thenReturn("jwt-token");
-
-        kakaoAuthService.kakaoLogin("auth-code");
-
-        assertThat(existing.getNickname()).isEqualTo("기존닉네임");
-        verify(userRepository, never()).save(any());
-    }
-
+    @DisplayName("카카오 토큰 발급에 실패하면 KakaoAuthException이 발생한다")
     @Test
     void 카카오_토큰_실패시_KakaoAuthException_발생() {
         when(postResponseSpec.body(KakaoDto.TokenResponse.class))

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.flover.flover_be.user.service;
 import com.flover.flover_be.global.storage.StorageDto;
 import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
 import com.flover.flover_be.plogging.repository.PloggingSessionRepository.PloggingStatsView;
+import com.flover.flover_be.user.domain.OAuthProvider;
 import com.flover.flover_be.user.domain.User;
 import com.flover.flover_be.user.dto.UserDto;
 import com.flover.flover_be.user.exception.UserErrorCode;
@@ -19,11 +20,12 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,13 +36,71 @@ class UserServiceTest {
     @Mock private PloggingSessionRepository ploggingSessionRepository;
     @InjectMocks private UserService userService;
 
+    private static User kakaoUser(String nickname, String imageUrl) {
+        return User.create(OAuthProvider.KAKAO, "12345", "test@test.com", nickname, imageUrl);
+    }
+
+    // ──────────────── upsertOAuthUser ────────────────
+
+    @DisplayName("신규 OAuth 유저는 DB에 저장하고 반환한다")
+    @Test
+    void upsert_oauth_user_신규_유저_저장() {
+        // given
+        given(userRepository.findByProviderAndProviderId(OAuthProvider.APPLE, "apple.user.001"))
+                .willReturn(Optional.empty());
+        given(userRepository.existsByNickname(anyString())).willReturn(false);
+        given(userRepository.save(any(User.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        User result = userService.upsertOAuthUser(OAuthProvider.APPLE, "apple.user.001", "user@apple.com");
+
+        // then
+        assertThat(result.getProvider()).isEqualTo(OAuthProvider.APPLE);
+        assertThat(result.getProviderId()).isEqualTo("apple.user.001");
+        assertThat(result.getNickname()).matches("플러버\\d{6}");
+        verify(userRepository).save(any(User.class));
+    }
+
+    @DisplayName("기존 OAuth 유저는 저장 없이 반환한다")
+    @Test
+    void upsert_oauth_user_기존_유저_반환() {
+        // given
+        User existing = User.create(OAuthProvider.APPLE, "apple.user.001", "user@apple.com", "플러버111111", null);
+        given(userRepository.findByProviderAndProviderId(OAuthProvider.APPLE, "apple.user.001"))
+                .willReturn(Optional.of(existing));
+
+        // when
+        User result = userService.upsertOAuthUser(OAuthProvider.APPLE, "apple.user.001", "other@apple.com");
+
+        // then
+        assertThat(result.getNickname()).isEqualTo("플러버111111");
+        verify(userRepository, never()).save(any());
+    }
+
+    @DisplayName("기본 닉네임이 중복이면 재생성한다")
+    @Test
+    void upsert_oauth_user_닉네임_중복_재생성() {
+        // given
+        given(userRepository.findByProviderAndProviderId(OAuthProvider.APPLE, "apple.user.001"))
+                .willReturn(Optional.empty());
+        given(userRepository.existsByNickname(anyString())).willReturn(true).willReturn(false);
+        given(userRepository.save(any(User.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        userService.upsertOAuthUser(OAuthProvider.APPLE, "apple.user.001", null);
+
+        // then
+        verify(userRepository, times(2)).existsByNickname(anyString());
+    }
+
+    // ──────────────── findUserInfo ────────────────
+
     @DisplayName("유저 정보를 정상적으로 조회한다")
     @Test
     void find_user_info_성공() {
         // given
         Long userId = 1L;
-        User user = User.create(1L, "test@test.com", "닉네임", "https://img.url/profile.png");
-
+        User user = kakaoUser("닉네임", "https://img.url/profile.png");
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when
@@ -65,22 +125,22 @@ class UserServiceTest {
                 .isInstanceOf(UserException.class);
     }
 
+    // ──────────────── updateNickname ────────────────
+
     @DisplayName("닉네임을 정상적으로 변경한다")
     @Test
     void update_nickname_성공() {
         // given
         Long userId = 1L;
-        String newNickname = "새닉네임";
-        User user = User.create(1L, "test@test.com", "기존닉네임", null);
-
+        User user = kakaoUser("기존닉네임", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(userRepository.existsByNickname(newNickname)).willReturn(false);
+        given(userRepository.existsByNickname("새닉네임")).willReturn(false);
 
         // when
-        UserDto.NicknameResponse result = userService.updateNickname(userId, newNickname);
+        UserDto.NicknameResponse result = userService.updateNickname(userId, "새닉네임");
 
         // then
-        assertThat(result.nickname()).isEqualTo(newNickname);
+        assertThat(result.nickname()).isEqualTo("새닉네임");
     }
 
     @DisplayName("존재하지 않는 유저의 닉네임 변경 시 예외가 발생한다")
@@ -100,14 +160,12 @@ class UserServiceTest {
     void update_nickname_중복_닉네임_예외() {
         // given
         Long userId = 1L;
-        String duplicateNickname = "중복닉네임";
-        User user = User.create(1L, "test@test.com", "기존닉네임", null);
-
+        User user = kakaoUser("기존닉네임", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(userRepository.existsByNickname(duplicateNickname)).willReturn(true);
+        given(userRepository.existsByNickname("중복닉네임")).willReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> userService.updateNickname(userId, duplicateNickname))
+        assertThatThrownBy(() -> userService.updateNickname(userId, "중복닉네임"))
                 .isInstanceOf(UserException.class);
     }
 
@@ -116,17 +174,17 @@ class UserServiceTest {
     void update_nickname_같은_닉네임이면_중복_검사_건너뜀() {
         // given
         Long userId = 1L;
-        String sameNickname = "기존닉네임";
-        User user = User.create(1L, "test@test.com", sameNickname, null);
-
+        User user = kakaoUser("기존닉네임", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when
-        userService.updateNickname(userId, sameNickname);
+        userService.updateNickname(userId, "기존닉네임");
 
         // then
         verify(userRepository, never()).existsByNickname(anyString());
     }
+
+    // ──────────────── generateProfileImagePresignedUrl ────────────────
 
     @DisplayName("Presigned URL 발급 시 유저 존재 확인 후 URL을 반환한다")
     @Test
@@ -136,7 +194,7 @@ class UserServiceTest {
         String contentType = "image/png";
         String uploadUrl = "https://bucket.s3.amazonaws.com/presigned";
         String imageUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/uuid.png";
-        User user = User.create(1L, "test@test.com", "nickname", null);
+        User user = kakaoUser("nickname", null);
         StorageDto.PresignedUploadUrlResponse expected = new StorageDto.PresignedUploadUrlResponse(uploadUrl, imageUrl);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
@@ -161,14 +219,15 @@ class UserServiceTest {
                 .isInstanceOf(UserException.class);
     }
 
+    // ──────────────── saveProfileImageUrl ────────────────
+
     @DisplayName("기존 프로필 이미지가 없을 때 새 URL을 저장한다")
     @Test
     void save_profile_image_url_기존없음_성공() {
         // given
         Long userId = 1L;
         String newImageUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/uuid.png";
-        User user = User.create(1L, "test@test.com", "nickname", null);
-
+        User user = kakaoUser("nickname", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when
@@ -187,8 +246,7 @@ class UserServiceTest {
         Long userId = 1L;
         String oldImageUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/old.png";
         String newImageUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/new.png";
-        User user = User.create(1L, "test@test.com", "nickname", oldImageUrl);
-
+        User user = kakaoUser("nickname", oldImageUrl);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when
@@ -205,8 +263,7 @@ class UserServiceTest {
         // given
         Long userId = 1L;
         String sameUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/uuid.png";
-        User user = User.create(1L, "test@test.com", "nickname", sameUrl);
-
+        User user = kakaoUser("nickname", sameUrl);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when
@@ -227,12 +284,14 @@ class UserServiceTest {
                 .isInstanceOf(UserException.class);
     }
 
+    // ──────────────── findPloggingStats ────────────────
+
     @DisplayName("플로깅 기록이 있는 사용자의 누적 통계를 반환한다")
     @Test
     void find_plogging_stats_성공() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = kakaoUser("닉네임", null);
         PloggingStatsView stats = mockStats(3L, 12000L, 8500L);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
@@ -252,7 +311,7 @@ class UserServiceTest {
     void find_plogging_stats_기록없음_모두_0() {
         // given
         Long userId = 1L;
-        User user = User.create(12345L, "test@test.com", "닉네임", null);
+        User user = kakaoUser("닉네임", null);
         PloggingStatsView stats = mockStats(0L, 0L, 0L);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));


### PR DESCRIPTION
## 관련 이슈
 

  ## 작업 내용
  - `OAuthProvider` enum 추가 (KAKAO, APPLE, GOOGLE) 및 User 엔티티 리팩토링
    - 기존 `kakaoId(Long)` 단일 필드 → `provider(OAuthProvider)` + `providerId(String)` 공통 구조로 변경
    - `(provider, provider_id)` 복합 유니크 제약 적용
    - 향후 Google 등 신규 소셜 로그인 추가 시 엔티티/DB 변경 없이 확장 가능
  - `UserService.upsertOAuthUser()` 공통 메서드 추가 — 모든 소셜 로그인이 단일 메서드로 신규/기존 유저 처리
  - Apple 소셜 로그인 구현 (`POST /api/auth/apple/login`)
    - iOS 앱에서 전달한 `identityToken`을 Apple JWKS 공개키로 RS256 서명 검증
    - `iss`, `aud`(Bundle ID) claims 검증 후 `sub`를 `providerId`로 저장
    - 추가 라이브러리 없이 JJWT 0.12.6 + Java 표준 RSA로 구현
  - 배포 파이프라인(`deploy.yml`)에 `APPLE_CLIENT_ID` 환경변수 추가
  - 기존에는 닉네임을 카카오톡 프로필에서 가져왔으나, 애플에서는 그 기능을 사용할 수 없기에 임의 닉네임 생성 기능 구현 (플러버 + 랜덤 숫자)

  ## DB 마이그레이션
  배포 전 아래 SQL을 순서대로 실행해야 합니다.
  ```sql
  ALTER TABLE users ADD COLUMN provider VARCHAR(20) NULL;
  ALTER TABLE users ADD COLUMN provider_id VARCHAR(255) NULL;
  UPDATE users SET provider = 'KAKAO', provider_id = CAST(kakao_id AS CHAR);
  ALTER TABLE users MODIFY COLUMN provider VARCHAR(20) NOT NULL;
  ALTER TABLE users MODIFY COLUMN provider_id VARCHAR(255) NOT NULL;
  ALTER TABLE users ADD UNIQUE KEY uk_provider_provider_id (provider, provider_id);
  ALTER TABLE users DROP COLUMN kakao_id;
```

  ## 테스트

  - 로컬에서 정상 동작을 확인했습니다.
  - 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.
    - AppleAuthServiceTest 신규 작성 (RS256 서명 검증, claims 검증, JWKS 실패 등 7개)
    - UserServiceTest upsertOAuthUser 테스트 3개 추가
    - KakaoAuthServiceTest UserService 목 구조로 수정
    - UserTest, PloggingServiceTest User.create() 시그니처 변경 반영

  ## 체크리스트

  - 관련 없는 변경이나 내용은 포함하지 않았습니다.
  - 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
  - 머지 전 스스로 한 번 더 확인했습니다.

