### PR TITLE
feat: deploy.yml에 환경 변수 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
                      JWT_SECRET JWT_EXPIRATION \
                      AWS_REGION AWS_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY \
                      AI_SERVER_URL AI_API_KEY ROUTE_ENGINE_URL \
-                     EC2_HOST EC2_USER EC2_SSH_KEY; do
+                     EC2_HOST EC2_USER EC2_SSH_KEY APPLE_CLIENT_ID; do
             if [ -z "${!VAR}" ]; then
               MISSING+=("$VAR")
             fi
@@ -91,11 +91,12 @@ jobs:
           AI_API_KEY: ${{ secrets.AI_API_KEY }}
           ROUTE_ENGINE_URL: ${{ secrets.ROUTE_ENGINE_URL }}
           APP_IMAGE: ${{ secrets.DOCKER_HUB_USERNAME }}/flover-be:latest
+          APPLE_CLIENT_ID: ${{ secrets.APPLE_CLIENT_ID }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,JWT_SECRET,JWT_EXPIRATION,AWS_REGION,AWS_S3_BUCKET,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AI_SERVER_URL,AI_API_KEY,ROUTE_ENGINE_URL,APP_IMAGE
+          envs: DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,JWT_SECRET,JWT_EXPIRATION,AWS_REGION,AWS_S3_BUCKET,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AI_SERVER_URL,AI_API_KEY,ROUTE_ENGINE_URL,APP_IMAGE,APPLE_CLIENT_ID
           script: |
             cd ~/flover-be
             git pull origin develop
@@ -117,6 +118,7 @@ jobs:
             AI_API_KEY=${AI_API_KEY}
             ROUTE_ENGINE_URL=${ROUTE_ENGINE_URL}
             APP_IMAGE=${APP_IMAGE}
+            APPLE_CLIENT_ID=${APPLE_CLIENT_ID}
             EOF
 
             docker compose pull app


### PR DESCRIPTION
## 관련 이슈
- close # (이슈 번호)

## 작업 내용
- Apple 로그인 환경변수 누락 문제 해결 (deploy.yml)
- GitHub Actions를 통한 EC2 배포 시, APPLE_CLIENT_ID 환경변수가 원격 서버로 전달되지 않던 현상을 수정했습니다.
- validate-secrets 잡의 검증 루프 리스트에 APPLE_CLIENT_ID를 추가했습니다.
- deploy 잡의 env 설정, envs 전송 목록, 그리고 EC2 내 .env 파일을 동적으로 생성하는 스크립트 본문에 해당 변수를 누락 없이 매핑했습니다.

## 결과
- GitHub Secrets의 실제 값이 인스턴스 내 .env 파일에 정상 주입되어, Spring Boot가 문자열${APPLE_CLIENT_ID}을 그대로 읽어 aud Mismatch 에러를 내던 문제를 해결했습니다.

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.
