### PR TITLE
[feat]: 로그아웃, 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingPhotoRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingPhotoRepository.java
@@ -2,10 +2,17 @@ package com.flover.flover_be.plogging.repository;
 
 import com.flover.flover_be.plogging.domain.PloggingPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PloggingPhotoRepository extends JpaRepository<PloggingPhoto, Long> {
 
     List<PloggingPhoto> findAllByPloggingSessionIdOrderBySequenceAsc(Long ploggingSessionId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM PloggingPhoto p WHERE p.ploggingSession.user.id = :userId")
+    void deleteByPloggingSessionUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingRoutePointRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingRoutePointRepository.java
@@ -2,6 +2,13 @@ package com.flover.flover_be.plogging.repository;
 
 import com.flover.flover_be.plogging.domain.PloggingRoutePoint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PloggingRoutePointRepository extends JpaRepository<PloggingRoutePoint, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM PloggingRoutePoint r WHERE r.ploggingSession.user.id = :userId")
+    void deleteByPloggingSessionUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
+++ b/src/main/java/com/flover/flover_be/plogging/repository/PloggingSessionRepository.java
@@ -4,6 +4,7 @@ import com.flover.flover_be.plogging.domain.PloggingSession;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -36,4 +37,8 @@ public interface PloggingSessionRepository extends JpaRepository<PloggingSession
         int getCaloriesBurned();
         int getPloggingSeconds();
     }
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM PloggingSession s WHERE s.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/flover/flover_be/user/controller/AuthController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.flover.flover_be.user.controller;
 
+import com.flover.flover_be.global.auth.LoginUserId;
 import com.flover.flover_be.user.dto.AppleDto;
 import com.flover.flover_be.user.dto.AuthDto;
 import com.flover.flover_be.user.service.AppleAuthService;
@@ -39,5 +40,11 @@ public class AuthController {
     ) {
         AuthDto.LoginResponse response = appleAuthService.appleLogin(request.identityToken());
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "로그아웃", description = "서버 처리 없이 204 반환. 클라이언트가 토큰을 삭제해야 합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@LoginUserId Long userId) {
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/flover/flover_be/user/controller/UserController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/UserController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -64,5 +65,12 @@ public class UserController {
             @RequestBody @Valid UserDto.ProfileImageUrlRequest request
     ) {
         return ResponseEntity.ok(userService.saveProfileImageUrl(userId, request.imageUrl()));
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "계정 및 모든 연관 데이터를 삭제합니다.")
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteAccount(@LoginUserId Long userId) {
+        userService.deleteUser(userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/flover/flover_be/user/service/AppleAuthService.java
+++ b/src/main/java/com/flover/flover_be/user/service/AppleAuthService.java
@@ -27,6 +27,7 @@ import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
+import java.util.List;
 import java.util.Set;
 
 @Slf4j
@@ -57,6 +58,7 @@ public class AppleAuthService {
     }
 
     private Claims verifyIdentityToken(String identityToken) {
+        logDecodedTokenInfo(identityToken);
         String kid = extractKid(identityToken);
         PublicKey publicKey = fetchApplePublicKey(kid);
 
@@ -72,11 +74,32 @@ public class AppleAuthService {
         } catch (AppleAuthException e) {
             throw e;
         } catch (JwtException e) {
-            log.error("Apple identityToken 서명 검증 실패: {}", e.getMessage());
+            log.error("[Apple] 서명 검증 실패 — {}: {}", e.getClass().getSimpleName(), e.getMessage());
             throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
         } catch (Exception e) {
-            log.error("Apple identityToken 처리 중 오류: {}", e.getMessage());
+            log.error("[Apple] identityToken 처리 오류 — {}: {}", e.getClass().getSimpleName(), e.getMessage(), e);
             throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
+        }
+    }
+
+    // 서명 검증 전에 만료 여부와 aud를 미리 확인해 실패 원인을 로그로 남긴다
+    private void logDecodedTokenInfo(String identityToken) {
+        try {
+            String[] parts = identityToken.split("\\.");
+            JsonNode payload = objectMapper.readTree(Base64.getUrlDecoder().decode(parts[1]));
+
+            long exp = payload.path("exp").asLong();
+            long now = System.currentTimeMillis() / 1000;
+            if (exp < now) {
+                log.error("[Apple] 토큰 만료 — {}초 전 만료 (exp={}, now={})", now - exp, exp, now);
+            }
+
+            String aud = payload.path("aud").asText();
+            if (!appleProperties.clientId().equals(aud)) {
+                log.error("[Apple] aud 불일치 — 토큰: {}, 설정: {}", aud, appleProperties.clientId());
+            }
+        } catch (Exception e) {
+            log.warn("[Apple] 토큰 사전 디코딩 실패: {}", e.getMessage());
         }
     }
 
@@ -87,12 +110,14 @@ public class AppleAuthService {
             JsonNode header = objectMapper.readTree(headerBytes);
             String kid = header.path("kid").asText(null);
             if (kid == null) {
+                log.error("[Apple] 토큰 헤더에 kid 없음");
                 throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
             }
             return kid;
         } catch (AppleAuthException e) {
             throw e;
         } catch (Exception e) {
+            log.error("[Apple] kid 추출 실패: {}", e.getMessage());
             throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
         }
     }
@@ -105,18 +130,24 @@ public class AppleAuthService {
                     .retrieve()
                     .body(AppleDto.JwksResponse.class);
         } catch (RestClientException e) {
-            log.error("Apple JWKS 조회 실패: {}", e.getMessage());
+            log.error("[Apple DEBUG] JWKS 조회 실패: {}", e.getMessage());
             throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
         }
 
         if (jwks == null) {
+            log.error("[Apple] JWKS 응답이 null");
             throw new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
         }
+
+        List<String> availableKids = jwks.keys().stream().map(AppleDto.JwksKey::kid).toList();
 
         AppleDto.JwksKey matchedKey = jwks.keys().stream()
                 .filter(key -> kid.equals(key.kid()))
                 .findFirst()
-                .orElseThrow(() -> new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN));
+                .orElseThrow(() -> {
+                    log.error("[Apple] kid 불일치 — 토큰 kid: {}, JWKS kids: {}", kid, availableKids);
+                    return new AppleAuthException(AuthErrorCode.APPLE_INVALID_TOKEN);
+                });
 
         return buildRsaPublicKey(matchedKey);
     }

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.flover.flover_be.user.service;
 
 import com.flover.flover_be.global.storage.StorageDto;
+import com.flover.flover_be.plogging.repository.PloggingPhotoRepository;
+import com.flover.flover_be.plogging.repository.PloggingRoutePointRepository;
 import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
 import com.flover.flover_be.user.domain.OAuthProvider;
 import com.flover.flover_be.user.domain.User;
@@ -21,6 +23,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final ProfileImageStorageService profileImageStorageService;
     private final PloggingSessionRepository ploggingSessionRepository;
+    private final PloggingPhotoRepository ploggingPhotoRepository;
+    private final PloggingRoutePointRepository ploggingRoutePointRepository;
 
     @Transactional(readOnly = true)
     public UserDto.UserInfoResponse findUserInfo(Long userId) {
@@ -79,6 +83,18 @@ public class UserService {
             nickname = "플러버" + suffix;
         } while (userRepository.existsByNickname(nickname));
         return nickname;
+    }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = getUserOrThrow(userId);
+        if (user.getProfileImageUrl() != null) {
+            profileImageStorageService.deleteIfOwnedByBucket(user.getProfileImageUrl());
+        }
+        ploggingPhotoRepository.deleteByPloggingSessionUserId(userId);
+        ploggingRoutePointRepository.deleteByPloggingSessionUserId(userId);
+        ploggingSessionRepository.deleteByUserId(userId);
+        userRepository.delete(user);
     }
 
     private User getUserOrThrow(Long userId) {

--- a/src/main/java/com/flover/flover_be/user/service/UserService.java
+++ b/src/main/java/com/flover/flover_be/user/service/UserService.java
@@ -13,6 +13,8 @@ import com.flover.flover_be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -88,13 +90,21 @@ public class UserService {
     @Transactional
     public void deleteUser(Long userId) {
         User user = getUserOrThrow(userId);
-        if (user.getProfileImageUrl() != null) {
-            profileImageStorageService.deleteIfOwnedByBucket(user.getProfileImageUrl());
-        }
+        String profileImageUrl = user.getProfileImageUrl();
+
         ploggingPhotoRepository.deleteByPloggingSessionUserId(userId);
         ploggingRoutePointRepository.deleteByPloggingSessionUserId(userId);
         ploggingSessionRepository.deleteByUserId(userId);
         userRepository.delete(user);
+
+        if (profileImageUrl != null) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    profileImageStorageService.deleteIfOwnedByBucket(profileImageUrl);
+                }
+            });
+        }
     }
 
     private User getUserOrThrow(Long userId) {

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -14,10 +14,14 @@ import com.flover.flover_be.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.Optional;
 
@@ -28,6 +32,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -353,25 +358,36 @@ class UserServiceTest {
 
     // ──────────────── deleteUser ────────────────
 
-    @DisplayName("프로필 이미지가 있는 유저 탈퇴 시 S3 이미지 삭제 후 FK 순서에 맞게 데이터를 제거한다")
+    @DisplayName("프로필 이미지가 있는 유저 탈퇴 시 DB 삭제 완료 후 트랜잭션 커밋 시점에 S3 이미지를 삭제한다")
     @Test
-    void delete_user_프로필이미지있음_S3삭제_후_순서대로_데이터삭제() {
+    void delete_user_프로필이미지있음_DB삭제_후_커밋시점에_S3삭제() {
         // given
         Long userId = 1L;
         String profileImageUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/img.png";
         User user = kakaoUser("닉네임", profileImageUrl);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
-        // when
-        userService.deleteUser(userId);
+        try (MockedStatic<TransactionSynchronizationManager> txSync = mockStatic(TransactionSynchronizationManager.class)) {
+            ArgumentCaptor<TransactionSynchronization> syncCaptor = ArgumentCaptor.forClass(TransactionSynchronization.class);
 
-        // then
-        verify(profileImageStorageService).deleteIfOwnedByBucket(profileImageUrl);
-        InOrder inOrder = inOrder(ploggingPhotoRepository, ploggingRoutePointRepository, ploggingSessionRepository, userRepository);
-        inOrder.verify(ploggingPhotoRepository).deleteByPloggingSessionUserId(userId);
-        inOrder.verify(ploggingRoutePointRepository).deleteByPloggingSessionUserId(userId);
-        inOrder.verify(ploggingSessionRepository).deleteByUserId(userId);
-        inOrder.verify(userRepository).delete(user);
+            // when
+            userService.deleteUser(userId);
+
+            // then - DB 삭제가 FK 순서대로 실행됐는지 확인
+            InOrder inOrder = inOrder(ploggingPhotoRepository, ploggingRoutePointRepository, ploggingSessionRepository, userRepository);
+            inOrder.verify(ploggingPhotoRepository).deleteByPloggingSessionUserId(userId);
+            inOrder.verify(ploggingRoutePointRepository).deleteByPloggingSessionUserId(userId);
+            inOrder.verify(ploggingSessionRepository).deleteByUserId(userId);
+            inOrder.verify(userRepository).delete(user);
+
+            // S3 삭제는 커밋 이후에 실행되도록 등록됐는지 확인
+            txSync.verify(() -> TransactionSynchronizationManager.registerSynchronization(syncCaptor.capture()));
+            verify(profileImageStorageService, never()).deleteIfOwnedByBucket(any());
+
+            // 커밋 시점 시뮬레이션 → afterCommit 호출 시 S3 삭제 실행
+            syncCaptor.getValue().afterCommit();
+            verify(profileImageStorageService).deleteIfOwnedByBucket(profileImageUrl);
+        }
     }
 
     @DisplayName("프로필 이미지가 없는 유저 탈퇴 시 S3 삭제 없이 데이터를 제거한다")

--- a/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
+++ b/src/test/java/com/flover/flover_be/user/service/UserServiceTest.java
@@ -1,6 +1,8 @@
 package com.flover.flover_be.user.service;
 
 import com.flover.flover_be.global.storage.StorageDto;
+import com.flover.flover_be.plogging.repository.PloggingPhotoRepository;
+import com.flover.flover_be.plogging.repository.PloggingRoutePointRepository;
 import com.flover.flover_be.plogging.repository.PloggingSessionRepository;
 import com.flover.flover_be.plogging.repository.PloggingSessionRepository.PloggingStatsView;
 import com.flover.flover_be.user.domain.OAuthProvider;
@@ -12,6 +14,7 @@ import com.flover.flover_be.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -34,6 +38,8 @@ class UserServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private ProfileImageStorageService profileImageStorageService;
     @Mock private PloggingSessionRepository ploggingSessionRepository;
+    @Mock private PloggingPhotoRepository ploggingPhotoRepository;
+    @Mock private PloggingRoutePointRepository ploggingRoutePointRepository;
     @InjectMocks private UserService userService;
 
     private static User kakaoUser(String nickname, String imageUrl) {
@@ -343,5 +349,60 @@ class UserServiceTest {
             public long getTotalStepCount() { return totalStepCount; }
             public long getTotalDistanceMeters() { return totalDistanceMeters; }
         };
+    }
+
+    // ──────────────── deleteUser ────────────────
+
+    @DisplayName("프로필 이미지가 있는 유저 탈퇴 시 S3 이미지 삭제 후 FK 순서에 맞게 데이터를 제거한다")
+    @Test
+    void delete_user_프로필이미지있음_S3삭제_후_순서대로_데이터삭제() {
+        // given
+        Long userId = 1L;
+        String profileImageUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/img.png";
+        User user = kakaoUser("닉네임", profileImageUrl);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        userService.deleteUser(userId);
+
+        // then
+        verify(profileImageStorageService).deleteIfOwnedByBucket(profileImageUrl);
+        InOrder inOrder = inOrder(ploggingPhotoRepository, ploggingRoutePointRepository, ploggingSessionRepository, userRepository);
+        inOrder.verify(ploggingPhotoRepository).deleteByPloggingSessionUserId(userId);
+        inOrder.verify(ploggingRoutePointRepository).deleteByPloggingSessionUserId(userId);
+        inOrder.verify(ploggingSessionRepository).deleteByUserId(userId);
+        inOrder.verify(userRepository).delete(user);
+    }
+
+    @DisplayName("프로필 이미지가 없는 유저 탈퇴 시 S3 삭제 없이 데이터를 제거한다")
+    @Test
+    void delete_user_프로필이미지없음_S3삭제없이_데이터삭제() {
+        // given
+        Long userId = 1L;
+        User user = kakaoUser("닉네임", null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        userService.deleteUser(userId);
+
+        // then
+        verify(profileImageStorageService, never()).deleteIfOwnedByBucket(any());
+        verify(ploggingPhotoRepository).deleteByPloggingSessionUserId(userId);
+        verify(ploggingRoutePointRepository).deleteByPloggingSessionUserId(userId);
+        verify(ploggingSessionRepository).deleteByUserId(userId);
+        verify(userRepository).delete(user);
+    }
+
+    @DisplayName("존재하지 않는 유저 탈퇴 시 예외가 발생하고 삭제 로직이 실행되지 않는다")
+    @Test
+    void delete_user_유저없음_예외() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteUser(1L))
+                .isInstanceOf(UserException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+        verify(userRepository, never()).delete(any(User.class));
     }
 }


### PR DESCRIPTION
## 관련 이슈
                                           

  ## 작업 내용
  - `POST /api/auth/logout` — 인증된 사용자의 로그아웃 요청을 받아 204 반환 (토큰 
  삭제는 클라이언트 처리)                                         
  - `DELETE /api/users/me` — 계정 및 연관 데이터 하드 삭제 (S3 프로필 이미지 →    
  플로깅 사진/루트 포인트/세션 → 유저 순으로 FK 제약 준수하여 삭제)
  - Apple 로그인 실패 시 원인 로그 추가 (토큰 만료, aud 불일치, kid 불일치, 서명  
  검증 실패 구분)

  ## 테스트
  - [x] 로컬에서 정상 동작을 확인했습니다.
  - [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.
    - `UserServiceTest` — 회원탈퇴 3케이스 추가 (프로필 이미지 있음/없음/유저     
  없음)
    - `UserService` 의존성 추가에 따른 기존 테스트 `@Mock` 누락 수정

  ## 체크리스트
  - [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
  - [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
  - [x] 머지 전 스스로 한 번 더 확인했습니다.
