### PR TITLE
[feat]: 카카오 Native SDK 로그인 방식 추가 (v2)

### DIFF
--- a/src/main/java/com/flover/flover_be/user/controller/AuthController.java
+++ b/src/main/java/com/flover/flover_be/user/controller/AuthController.java
@@ -24,12 +24,21 @@ public class AuthController {
     private final KakaoAuthService kakaoAuthService;
     private final AppleAuthService appleAuthService;
 
-    @Operation(summary = "카카오 로그인", description = "프론트에서 받은 인가 코드로 JWT 토큰 발급")
+    @Operation(summary = "카카오 로그인 (Code 방식, Deprecated)", description = "WebView 방식. 인가 코드로 JWT 발급. Native SDK 전환 완료 후 제거 예정.")
     @PostMapping("/kakao/login")
     public ResponseEntity<AuthDto.LoginResponse> kakaoLogin(
             @RequestBody @Valid AuthDto.CallbackRequest request
     ) {
         AuthDto.LoginResponse response = kakaoAuthService.kakaoLogin(request.code());
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "카카오 로그인 (Native SDK 방식)", description = "카카오 Native SDK에서 발급받은 accessToken으로 JWT 발급")
+    @PostMapping("/v2/kakao/login")
+    public ResponseEntity<AuthDto.LoginResponse> kakaoLoginV2(
+            @RequestBody @Valid AuthDto.KakaoTokenRequest request
+    ) {
+        AuthDto.LoginResponse response = kakaoAuthService.kakaoLoginWithToken(request.accessToken());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/flover/flover_be/user/dto/AuthDto.java
+++ b/src/main/java/com/flover/flover_be/user/dto/AuthDto.java
@@ -6,6 +6,8 @@ public class AuthDto {
 
     public record CallbackRequest(@NotBlank String code) {}
 
+    public record KakaoTokenRequest(@NotBlank String accessToken) {}
+
     public record LoginResponse(
             String accessToken,
             String tokenType,

--- a/src/main/java/com/flover/flover_be/user/exception/AuthErrorCode.java
+++ b/src/main/java/com/flover/flover_be/user/exception/AuthErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ErrorCode {
 
     KAKAO_TOKEN_FAILED(HttpStatus.UNAUTHORIZED, "카카오 토큰 발급에 실패했습니다."),
+    KAKAO_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "카카오 액세스 토큰이 유효하지 않거나 만료되었습니다."),
     KAKAO_USER_INFO_FAILED(HttpStatus.UNAUTHORIZED, "카카오 사용자 정보 조회에 실패했습니다."),
 
     APPLE_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Apple 토큰 검증에 실패했습니다."),

--- a/src/main/java/com/flover/flover_be/user/service/KakaoAuthService.java
+++ b/src/main/java/com/flover/flover_be/user/service/KakaoAuthService.java
@@ -38,7 +38,14 @@ public class KakaoAuthService {
         KakaoDto.UserInfoResponse userInfo = getKakaoUserInfo(kakaoAccessToken);
         User user = upsertUser(userInfo);
         String jwtToken = jwtProvider.generateToken(user.getId());
+        return new AuthDto.LoginResponse(jwtToken, "Bearer", user.getId(), user.getNickname(), user.getEmail());
+    }
 
+    @Transactional
+    public AuthDto.LoginResponse kakaoLoginWithToken(String accessToken) {
+        KakaoDto.UserInfoResponse userInfo = getKakaoUserInfo(accessToken);
+        User user = upsertUser(userInfo);
+        String jwtToken = jwtProvider.generateToken(user.getId());
         return new AuthDto.LoginResponse(jwtToken, "Bearer", user.getId(), user.getNickname(), user.getEmail());
     }
 
@@ -83,7 +90,14 @@ public class KakaoAuthService {
                 throw new KakaoAuthException(AuthErrorCode.KAKAO_USER_INFO_FAILED);
             }
             return response;
+        } catch (RestClientResponseException e) {
+            if (e.getStatusCode().value() == 401) {
+                throw new KakaoAuthException(AuthErrorCode.KAKAO_TOKEN_INVALID);
+            }
+            log.error("카카오 사용자 정보 조회 실패 - status: {}, body: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new KakaoAuthException(AuthErrorCode.KAKAO_USER_INFO_FAILED);
         } catch (RestClientException e) {
+            log.error("카카오 사용자 정보 조회 실패 - 네트워크 오류: {}", e.getMessage());
             throw new KakaoAuthException(AuthErrorCode.KAKAO_USER_INFO_FAILED);
         }
     }


### PR DESCRIPTION
## 관련 이슈
- close #54 

## 작업 내용
- 카카오 Native SDK 로그인 방식 지원을 위해 `POST /api/auth/v2/kakao/login` 엔드포인트 추가
- 기존 WebView 기반 code 방식(`POST /api/auth/kakao/login`)은 하위 호환을 위해 Deprecated 표기 후 유지
- `KAKAO_TOKEN_INVALID` 에러코드 추가 — accessToken 만료/위조 시 기존 `KAKAO_USER_INFO_FAILED`와 명확히 구분
- `getKakaoUserInfo`에서 카카오 서버 401 응답을 별도로 잡아 `KAKAO_TOKEN_INVALID` 예외 반환하도록 개선

### v1 vs v2 흐름 차이
| | v1 (기존, Deprecated) | v2 (신규) |
|---|---|---|
| 요청 바디 | `{ code }` | `{ accessToken }` |
| 백엔드 동작 | code → 카카오 토큰 교환 → 유저 조회 | 바로 유저 조회 |
| client_secret | 백엔드에서 사용 | 불필요 |

## 테스트
- [ ] 로컬에서 정상 동작을 확인했습니다.
- [x] 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.