### PR TITLE
feat: route-engine 다중 추천 경로 및 스코어링 API 연동 규격 개편

### DIFF
--- a/src/main/java/com/flover/flover_be/route/client/RouteEngineClient.java
+++ b/src/main/java/com/flover/flover_be/route/client/RouteEngineClient.java
@@ -13,13 +13,14 @@ import org.springframework.web.client.RestClient;
 
 import java.net.http.HttpClient;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
 
 @Slf4j
 @Component
 public class RouteEngineClient {
 
     private static final int MAX_RETRIES = 3;
-
     private final RestClient restClient;
 
     public RouteEngineClient(@Value("${route.engine.url}") String routeEngineUrl) {
@@ -40,10 +41,9 @@ public class RouteEngineClient {
         Exception lastException = null;
         for (int i = 0; i < MAX_RETRIES; i++) {
             try {
-                log.info("Requesting route from engine (Attempt {}): lat={}, lon={}, distance={}",
-                         i + 1, lat, lon, distance);
-
-                return restClient.get()
+                log.info("Requesting routes from engine (Attempt {}): lat={}, lon={}, distance={}",
+                        i + 1, lat, lon, distance);
+                RouteDto.RouteInfo[] routeInfos = restClient.get()
                         .uri(uriBuilder -> uriBuilder
                                 .path("/api/v1/route")
                                 .queryParam("lat", lat)
@@ -52,7 +52,10 @@ public class RouteEngineClient {
                                 .queryParam("mode", mode)
                                 .build())
                         .retrieve()
-                        .body(RouteDto.Response.class);
+                        .body(RouteDto.RouteInfo[].class);
+                return new RouteDto.Response(
+                        routeInfos != null ? Arrays.asList(routeInfos) : Collections.emptyList()
+                );
 
             } catch (ResourceAccessException | HttpServerErrorException e) {
                 log.warn("Route Engine API call failed on attempt {}: {}", i + 1, e.getMessage());

--- a/src/main/java/com/flover/flover_be/route/dto/RouteDto.java
+++ b/src/main/java/com/flover/flover_be/route/dto/RouteDto.java
@@ -2,6 +2,7 @@ package com.flover.flover_be.route.dto;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 
 public class RouteDto {
     public record Request(
@@ -17,9 +18,14 @@ public class RouteDto {
         }
     }
 
-    public record Response(
+    public record RouteInfo(
             double distanceMeter,
             long timeMillis,
-            String encodedPath
+            String encodedPath,
+            int ploggingScore
+    ) {}
+
+    public record Response(
+            List<RouteInfo> routes
     ) {}
 }

--- a/src/test/java/com/flover/flover_be/route/controller/RouteControllerTest.java
+++ b/src/test/java/com/flover/flover_be/route/controller/RouteControllerTest.java
@@ -16,6 +16,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -45,11 +47,13 @@ class RouteControllerTest {
                 .build();
     }
 
-    @DisplayName("정상 요청 시 200 OK와 경로 데이터를 반환한다")
+    @DisplayName("정상 요청 시 200 OK와 3개의 다중 추천 경로 목록 데이터를 반환한다")
     @Test
     void get_plogging_route_성공_200_반환() throws Exception {
         // given
-        RouteDto.Response mockResponse = new RouteDto.Response(2500.0, 605000, "encodedPathData");
+        RouteDto.Response mockResponse = new RouteDto.Response(
+                List.of(new RouteDto.RouteInfo(2500.0, 605000, "encodedPathData", 98))
+        );
         given(routeEngineClient.getRoute(anyDouble(), anyDouble(), anyInt(), anyString()))
                 .willReturn(mockResponse);
 
@@ -60,16 +64,19 @@ class RouteControllerTest {
                         .param("time", "30")
                         .param("mode", "PLOGGING"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.distanceMeter").value(2500.0))
-                .andExpect(jsonPath("$.timeMillis").value(605000))
-                .andExpect(jsonPath("$.encodedPath").value("encodedPathData"));
+                .andExpect(jsonPath("$.routes[0].distanceMeter").value(2500.0))
+                .andExpect(jsonPath("$.routes[0].timeMillis").value(605000))
+                .andExpect(jsonPath("$.routes[0].encodedPath").value("encodedPathData"))
+                .andExpect(jsonPath("$.routes[0].ploggingScore").value(98));
     }
 
     @DisplayName("time 파라미터가 30분일 때 distance 2500m로 변환되어 전달된다")
     @Test
     void get_plogging_route_시간_거리_변환_검증() throws Exception {
         // given
-        RouteDto.Response mockResponse = new RouteDto.Response(2500.0, 605000, "encodedPathData");
+        RouteDto.Response mockResponse = new RouteDto.Response(
+                List.of(new RouteDto.RouteInfo(2500.0, 605000, "encodedPathData", 98))
+        );
         given(routeEngineClient.getRoute(anyDouble(), anyDouble(), anyInt(), anyString()))
                 .willReturn(mockResponse);
 
@@ -91,7 +98,9 @@ class RouteControllerTest {
     @Test
     void get_plogging_route_기본_모드_PLOGGING() throws Exception {
         // given
-        RouteDto.Response mockResponse = new RouteDto.Response(2500.0, 605000, "encodedPathData");
+        RouteDto.Response mockResponse = new RouteDto.Response(
+                List.of(new RouteDto.RouteInfo(2500.0, 605000, "encodedPathData", 98))
+        );
         given(routeEngineClient.getRoute(anyDouble(), anyDouble(), anyInt(), anyString()))
                 .willReturn(mockResponse);
 


### PR DESCRIPTION
## 관련 이슈
- close # (이슈 번호)

## 작업 내용
- [DTO] RouteDto.Response를 단일 경로 반환 형태에서 3개 다중 경로 리스트 수신을 위한 List<RouteInfo> 구조로 개편하고 ploggingScore 필드 추가
- [Client] RouteEngineClient가 라우팅 엔진의 RouteInfo[] 배열 응답을 정상적으로 수신하여 Response 래퍼로 캡슐화하도록 API 호출 로직 리팩토링
- [Test] RouteControllerTest의 모킹 데이터를 다중 경로 래퍼 형태로 갱신하고 jsonPath 검증 경로를 $.routes[0] 하위 필드로 수정하여 API 응답 무결성 검증 완수

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.
