### PR TITLE
[feat]: 플로깅 완료 응답에 이전/현재 경험치 및 레벨 추가

### DIFF
--- a/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
+++ b/src/main/java/com/flover/flover_be/plogging/dto/PloggingDto.java
@@ -40,7 +40,13 @@ public class PloggingDto {
             @NotNull @DecimalMin("-180.0") @DecimalMax("180.0") Double longitude
     ) {}
 
-    public record CompleteResponse(Long ploggingSessionId) {}
+    public record CompleteResponse(
+            Long ploggingSessionId,
+            long previousExperience,
+            long currentExperience,
+            int previousLevel,
+            int currentLevel
+    ) {}
 
     public record SessionSummaryResponse(
             Long ploggingSessionId,

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingService.java
@@ -58,9 +58,11 @@ public class PloggingService {
         saveRoutePoints(savedSession, request.routePoints());
         savePhotos(savedSession, request.photoUrls());
 
+        long previousExperience = user.getExperience();
+        int previousLevel = user.getLevel();
         user.addPloggingTimeSeconds(request.ploggingSeconds());
 
-        return new PloggingDto.CompleteResponse(savedSession.getId());
+        return new PloggingDto.CompleteResponse(savedSession.getId(), previousExperience, user.getExperience(), previousLevel, user.getLevel());
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/service/PloggingServiceTest.java
@@ -70,6 +70,56 @@ class PloggingServiceTest {
         verify(ploggingSessionRepository).save(any(PloggingSession.class));
     }
 
+    @DisplayName("플로깅 완료 응답에 이전/현재 경험치와 레벨이 포함된다")
+    @Test
+    void complete_경험치_이전후_반환() {
+        // given
+        Long userId = 1L;
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
+        // ploggingSeconds=600 → experience = (600/5)*1 = 120, level = 1
+        PloggingDto.CompleteRequest request = buildRequest(List.of(), List.of());
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.save(any())).willAnswer(i -> i.getArgument(0));
+        given(ploggingRoutePointRepository.saveAll(any())).willReturn(List.of());
+        given(ploggingPhotoRepository.saveAll(any())).willReturn(List.of());
+
+        // when
+        PloggingDto.CompleteResponse result = ploggingService.complete(userId, request);
+
+        // then
+        assertThat(result.previousExperience()).isZero();
+        assertThat(result.currentExperience()).isEqualTo(120L);
+        assertThat(result.previousLevel()).isEqualTo(1);
+        assertThat(result.currentLevel()).isEqualTo(1);
+    }
+
+    @DisplayName("플로깅 완료 후 레벨업이 발생하면 이전/현재 레벨이 다르다")
+    @Test
+    void complete_레벨업_시_이전후_레벨_반환() {
+        // given
+        Long userId = 1L;
+        User user = User.create(OAuthProvider.KAKAO, "12345", "test@test.com", "닉네임", null);
+        // 미리 3300초 적립 → experience=660, level=1
+        user.addPloggingTimeSeconds(3300);
+        // ploggingSeconds=600 추가 → totalPloggingSeconds=3900, experience=780, level=2
+        PloggingDto.CompleteRequest request = buildRequest(List.of(), List.of());
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(ploggingSessionRepository.save(any())).willAnswer(i -> i.getArgument(0));
+        given(ploggingRoutePointRepository.saveAll(any())).willReturn(List.of());
+        given(ploggingPhotoRepository.saveAll(any())).willReturn(List.of());
+
+        // when
+        PloggingDto.CompleteResponse result = ploggingService.complete(userId, request);
+
+        // then
+        assertThat(result.previousExperience()).isEqualTo(660L);
+        assertThat(result.currentExperience()).isEqualTo(780L);
+        assertThat(result.previousLevel()).isEqualTo(1);
+        assertThat(result.currentLevel()).isEqualTo(2);
+    }
+
     @DisplayName("존재하지 않는 유저로 플로깅 완료 저장 시 예외가 발생한다")
     @Test
     void complete_유저없음_예외() {
@@ -186,6 +236,8 @@ class PloggingServiceTest {
 
         // then
         assertThat(result.ploggingSessionId()).isNull();
+        assertThat(result.previousExperience()).isNotNegative();
+        assertThat(result.currentExperience()).isGreaterThanOrEqualTo(result.previousExperience());
         verify(ploggingRoutePointRepository).saveAll(List.of());
         verify(ploggingPhotoRepository).saveAll(List.of());
     }


### PR DESCRIPTION
## 관련 이슈
- close #57

## 작업 내용
- `CompleteResponse`에 `previousExperience`, `currentExperience`, `previousLevel`, `currentLevel` 필드 추가
- 프론트엔드 경험치 애니메이션 UI를 위해 플로깅 완료 전/후 경험치와 레벨을 함께 반환
- `PloggingService.complete()`에서 `addPloggingTimeSeconds()` 호출 전 이전 값을 캡처해 응답에 포함

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.