### PR TITLE
[feat]: 쓰레기 분석 데이터 PostgreSQL에도 저장되게 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,10 @@ jobs:
           AI_SERVER_URL: ${{ secrets.AI_SERVER_URL }}
           AI_API_KEY: ${{ secrets.AI_API_KEY }}
           ROUTE_ENGINE_URL: ${{ secrets.ROUTE_ENGINE_URL }}
+          POSTGRES_DB_ENABLED: ${{ secrets.POSTGRES_DB_ENABLED }}
+          POSTGRES_DB_URL: ${{ secrets.POSTGRES_DB_URL }}
+          POSTGRES_DB_USERNAME: ${{ secrets.POSTGRES_DB_USERNAME }}
+          POSTGRES_DB_PASSWORD: ${{ secrets.POSTGRES_DB_PASSWORD }}
           EC2_HOST: ${{ secrets.EC2_HOST }}
           EC2_USER: ${{ secrets.EC2_USER }}
           EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
@@ -38,6 +42,7 @@ jobs:
                      JWT_SECRET JWT_EXPIRATION \
                      AWS_REGION AWS_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY \
                      AI_SERVER_URL AI_API_KEY ROUTE_ENGINE_URL \
+                     POSTGRES_DB_ENABLED POSTGRES_DB_URL POSTGRES_DB_USERNAME POSTGRES_DB_PASSWORD \
                      EC2_HOST EC2_USER EC2_SSH_KEY APPLE_CLIENT_ID; do
             if [ -z "${!VAR}" ]; then
               MISSING+=("$VAR")
@@ -90,13 +95,17 @@ jobs:
           AI_SERVER_URL: ${{ secrets.AI_SERVER_URL }}
           AI_API_KEY: ${{ secrets.AI_API_KEY }}
           ROUTE_ENGINE_URL: ${{ secrets.ROUTE_ENGINE_URL }}
+          POSTGRES_DB_ENABLED: ${{ secrets.POSTGRES_DB_ENABLED }}
+          POSTGRES_DB_URL: ${{ secrets.POSTGRES_DB_URL }}
+          POSTGRES_DB_USERNAME: ${{ secrets.POSTGRES_DB_USERNAME }}
+          POSTGRES_DB_PASSWORD: ${{ secrets.POSTGRES_DB_PASSWORD }}
           APP_IMAGE: ${{ secrets.DOCKER_HUB_USERNAME }}/flover-be:latest
           APPLE_CLIENT_ID: ${{ secrets.APPLE_CLIENT_ID }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,JWT_SECRET,JWT_EXPIRATION,AWS_REGION,AWS_S3_BUCKET,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AI_SERVER_URL,AI_API_KEY,ROUTE_ENGINE_URL,APP_IMAGE,APPLE_CLIENT_ID
+          envs: DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,JWT_SECRET,JWT_EXPIRATION,AWS_REGION,AWS_S3_BUCKET,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AI_SERVER_URL,AI_API_KEY,ROUTE_ENGINE_URL,POSTGRES_DB_ENABLED,POSTGRES_DB_URL,POSTGRES_DB_USERNAME,POSTGRES_DB_PASSWORD,APP_IMAGE,APPLE_CLIENT_ID
           script: |
             cd ~/flover-be
             git pull origin develop
@@ -117,6 +126,10 @@ jobs:
             AI_SERVER_URL=${AI_SERVER_URL}
             AI_API_KEY=${AI_API_KEY}
             ROUTE_ENGINE_URL=${ROUTE_ENGINE_URL}
+            POSTGRES_DB_ENABLED=${POSTGRES_DB_ENABLED}
+            POSTGRES_DB_URL=${POSTGRES_DB_URL}
+            POSTGRES_DB_USERNAME=${POSTGRES_DB_USERNAME}
+            POSTGRES_DB_PASSWORD=${POSTGRES_DB_PASSWORD}
             APP_IMAGE=${APP_IMAGE}
             APPLE_CLIENT_ID=${APPLE_CLIENT_ID}
             EOF

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3:2.25.70'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'org.postgresql:postgresql'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/flover/flover_be/global/config/PostgresDataSourceConfig.java
+++ b/src/main/java/com/flover/flover_be/global/config/PostgresDataSourceConfig.java
@@ -1,7 +1,7 @@
 package com.flover.flover_be.global.config;
 
 import com.zaxxer.hikari.HikariDataSource;
-import javax.sql.DataSource;
+import jakarta.annotation.PreDestroy;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -12,8 +12,10 @@ import org.springframework.jdbc.core.JdbcTemplate;
 @ConditionalOnProperty(prefix = "postgres.datasource", name = "enabled", havingValue = "true")
 public class PostgresDataSourceConfig {
 
-    @Bean(destroyMethod = "close")
-    public HikariDataSource postgresDataSource(
+    private HikariDataSource postgresDataSource;
+
+    @Bean
+    public JdbcTemplate postgresJdbcTemplate(
             @Value("${postgres.datasource.url}") String url,
             @Value("${postgres.datasource.username}") String username,
             @Value("${postgres.datasource.password}") String password,
@@ -26,11 +28,14 @@ public class PostgresDataSourceConfig {
         dataSource.setDriverClassName(driverClassName);
         dataSource.setMinimumIdle(1);
         dataSource.setMaximumPoolSize(5);
-        return dataSource;
+        this.postgresDataSource = dataSource;
+        return new JdbcTemplate(dataSource);
     }
 
-    @Bean
-    public JdbcTemplate postgresJdbcTemplate(DataSource postgresDataSource) {
-        return new JdbcTemplate(postgresDataSource);
+    @PreDestroy
+    public void closePostgresDataSource() {
+        if (postgresDataSource != null) {
+            postgresDataSource.close();
+        }
     }
 }

--- a/src/main/java/com/flover/flover_be/global/config/PostgresDataSourceConfig.java
+++ b/src/main/java/com/flover/flover_be/global/config/PostgresDataSourceConfig.java
@@ -1,28 +1,36 @@
 package com.flover.flover_be.global.config;
 
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 @Configuration
 @ConditionalOnProperty(prefix = "postgres.datasource", name = "enabled", havingValue = "true")
 public class PostgresDataSourceConfig {
 
-    @Bean
-    public JdbcTemplate postgresJdbcTemplate(
+    @Bean(destroyMethod = "close")
+    public HikariDataSource postgresDataSource(
             @Value("${postgres.datasource.url}") String url,
             @Value("${postgres.datasource.username}") String username,
             @Value("${postgres.datasource.password}") String password,
             @Value("${postgres.datasource.driver-class-name}") String driverClassName
     ) {
-        DriverManagerDataSource dataSource = new DriverManagerDataSource();
-        dataSource.setUrl(url);
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(url);
         dataSource.setUsername(username);
         dataSource.setPassword(password);
         dataSource.setDriverClassName(driverClassName);
-        return new JdbcTemplate(dataSource);
+        dataSource.setMinimumIdle(1);
+        dataSource.setMaximumPoolSize(5);
+        return dataSource;
+    }
+
+    @Bean
+    public JdbcTemplate postgresJdbcTemplate(DataSource postgresDataSource) {
+        return new JdbcTemplate(postgresDataSource);
     }
 }

--- a/src/main/java/com/flover/flover_be/global/config/PostgresDataSourceConfig.java
+++ b/src/main/java/com/flover/flover_be/global/config/PostgresDataSourceConfig.java
@@ -1,0 +1,28 @@
+package com.flover.flover_be.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@Configuration
+@ConditionalOnProperty(prefix = "postgres.datasource", name = "enabled", havingValue = "true")
+public class PostgresDataSourceConfig {
+
+    @Bean
+    public JdbcTemplate postgresJdbcTemplate(
+            @Value("${postgres.datasource.url}") String url,
+            @Value("${postgres.datasource.username}") String username,
+            @Value("${postgres.datasource.password}") String password,
+            @Value("${postgres.datasource.driver-class-name}") String driverClassName
+    ) {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setUrl(url);
+        dataSource.setUsername(username);
+        dataSource.setPassword(password);
+        dataSource.setDriverClassName(driverClassName);
+        return new JdbcTemplate(dataSource);
+    }
+}

--- a/src/main/java/com/flover/flover_be/plogging/controller/PloggingAnalysisController.java
+++ b/src/main/java/com/flover/flover_be/plogging/controller/PloggingAnalysisController.java
@@ -6,6 +6,7 @@ import com.flover.flover_be.plogging.service.PloggingAnalysisService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -36,7 +37,7 @@ public class PloggingAnalysisController {
     ) {
         try {
             byte[] imageBytes = image.getBytes();
-            ploggingAnalysisService.analyzeAsync(imageBytes, image.getOriginalFilename(), latitude, longitude);
+            ploggingAnalysisService.analyzeAsync(imageBytes, image.getOriginalFilename(), latitude, longitude, LocalDateTime.now());
         } catch (IOException e) {
             log.error("이미지 데이터 읽기 실패: {}", e.getMessage());
             throw new PloggingException(PloggingErrorCode.IMAGE_PROCESSING_FAILED);

--- a/src/main/java/com/flover/flover_be/plogging/service/PloggingAnalysisService.java
+++ b/src/main/java/com/flover/flover_be/plogging/service/PloggingAnalysisService.java
@@ -4,12 +4,16 @@ import com.flover.flover_be.plogging.domain.TrashDetection;
 import com.flover.flover_be.plogging.dto.AiResponseDto;
 import com.flover.flover_be.plogging.repository.TrashDetectionRepository;
 import java.util.ArrayList;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -21,25 +25,30 @@ import org.springframework.web.client.RestClientException;
 @Service
 public class PloggingAnalysisService {
 
+    private static final String RAW_TRASH_REPORT_PROVIDER = "plover";
+
     private final RestClient restClient;
     private final TrashDetectionRepository trashDetectionRepository;
+    private final ObjectProvider<JdbcTemplate> postgresJdbcTemplateProvider;
     private final String aiServerUrl;
     private final String aiApiKey;
 
     public PloggingAnalysisService(
             RestClient restClient,
             TrashDetectionRepository trashDetectionRepository,
+            @Qualifier("postgresJdbcTemplate") ObjectProvider<JdbcTemplate> postgresJdbcTemplateProvider,
             @Value("${ai.server.url}") String aiServerUrl,
             @Value("${ai.api.key}") String aiApiKey
     ) {
         this.restClient = restClient;
         this.trashDetectionRepository = trashDetectionRepository;
+        this.postgresJdbcTemplateProvider = postgresJdbcTemplateProvider;
         this.aiServerUrl = aiServerUrl;
         this.aiApiKey = aiApiKey;
     }
 
     @Async("aiAnalysisExecutor")
-    public void analyzeAsync(byte[] imageBytes, String filename, Double latitude, Double longitude) {
+    public void analyzeAsync(byte[] imageBytes, String filename, Double latitude, Double longitude, LocalDateTime reportedAt) {
         log.info("AI 이미지 분석 요청 시작: 위도={}, 경도={}", latitude, longitude);
         try {
             AiResponseDto response = callAiServer(imageBytes, filename, latitude, longitude);
@@ -48,7 +57,7 @@ public class PloggingAnalysisService {
                 log.warn("AI 서버로부터 유효하지 않은 응답 수신: status={}", response != null ? response.status() : "null");
                 return;
             }
-            saveDetections(response, latitude, longitude);
+            saveDetections(response, latitude, longitude, reportedAt);
             log.info("AI 이미지 분석 완료: 총 감지 항목 수={}", response.totalCount());
         } catch (RestClientException e) {
             log.error("AI 서버 연결 실패: {}", e.getMessage());
@@ -80,7 +89,7 @@ public class PloggingAnalysisService {
                 .body(AiResponseDto.class);
     }
 
-    private void saveDetections(AiResponseDto response, Double latitude, Double longitude) {
+    private void saveDetections(AiResponseDto response, Double latitude, Double longitude, LocalDateTime reportedAt) {
         Map<String, Integer> counts = response.counts();
 
         List<TrashDetection> detections = response.detections().stream()
@@ -93,7 +102,32 @@ public class PloggingAnalysisService {
                 ))
                 .toList();
 
-        trashDetectionRepository.saveAll(detections);
+        List<TrashDetection> savedDetections = trashDetectionRepository.saveAll(detections);
+        saveRawTrashReports(savedDetections, reportedAt);
         log.info("쓰레기 감지 결과 저장 완료: {}건", detections.size());
+    }
+
+    private void saveRawTrashReports(List<TrashDetection> detections, LocalDateTime reportedAt) {
+        JdbcTemplate postgresJdbcTemplate = postgresJdbcTemplateProvider.getIfAvailable();
+
+        if (postgresJdbcTemplate == null || detections.isEmpty()) {
+            return;
+        }
+
+        String sql = """
+                INSERT INTO raw_trash_reports (source_id, provider, reported_at, geometry)
+                VALUES (?, ?, ?, ST_SetSRID(ST_MakePoint(?, ?), 4326))
+                """;
+
+        for (TrashDetection detection : detections) {
+            postgresJdbcTemplate.update(
+                    sql,
+                    "trash_detection:" + detection.getId(),
+                    RAW_TRASH_REPORT_PROVIDER,
+                    reportedAt,
+                    detection.getLongitude(),
+                    detection.getLatitude()
+            );
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,13 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.show-sql=true
 
+# PostgreSQL
+postgres.datasource.enabled=${POSTGRES_DB_ENABLED:false}
+postgres.datasource.url=${POSTGRES_DB_URL:}
+postgres.datasource.username=${POSTGRES_DB_USERNAME:}
+postgres.datasource.password=${POSTGRES_DB_PASSWORD:}
+postgres.datasource.driver-class-name=org.postgresql.Driver
+
 # Kakao OAuth
 kakao.client-id=${KAKAO_CLIENT_ID}
 kakao.client-secret=${KAKAO_CLIENT_SECRET}

--- a/src/test/java/com/flover/flover_be/plogging/controller/PloggingAnalysisControllerTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/controller/PloggingAnalysisControllerTest.java
@@ -2,6 +2,7 @@ package com.flover.flover_be.plogging.controller;
 
 import com.flover.flover_be.global.exception.GlobalExceptionHandler;
 import com.flover.flover_be.plogging.service.PloggingAnalysisService;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,8 @@ class PloggingAnalysisControllerTest {
     @Test
     void analyze_image_성공_200_반환() throws Exception {
         // given
-        doNothing().when(ploggingAnalysisService).analyzeAsync(any(), anyString(), anyDouble(), anyDouble());
+        doNothing().when(ploggingAnalysisService)
+                .analyzeAsync(any(), anyString(), anyDouble(), anyDouble(), any(LocalDateTime.class));
 
         // when & then
         mockMvc.perform(multipart("/api/plogging/analyze")
@@ -62,7 +64,8 @@ class PloggingAnalysisControllerTest {
     @Test
     void analyze_image_서비스_호출() throws Exception {
         // given
-        doNothing().when(ploggingAnalysisService).analyzeAsync(any(), anyString(), anyDouble(), anyDouble());
+        doNothing().when(ploggingAnalysisService)
+                .analyzeAsync(any(), anyString(), anyDouble(), anyDouble(), any(LocalDateTime.class));
 
         // when
         mockMvc.perform(multipart("/api/plogging/analyze")
@@ -72,7 +75,8 @@ class PloggingAnalysisControllerTest {
                 .andExpect(status().isOk());
 
         // then
-        verify(ploggingAnalysisService).analyzeAsync(any(), anyString(), anyDouble(), anyDouble());
+        verify(ploggingAnalysisService)
+                .analyzeAsync(any(), anyString(), anyDouble(), anyDouble(), any(LocalDateTime.class));
     }
 
     @DisplayName("image 파트 없이 요청하면 400을 반환한다")
@@ -84,7 +88,7 @@ class PloggingAnalysisControllerTest {
                         .param("longitude", "127.0"))
                 .andExpect(status().isBadRequest());
 
-        verify(ploggingAnalysisService, never()).analyzeAsync(any(), any(), any(), any());
+        verify(ploggingAnalysisService, never()).analyzeAsync(any(), any(), any(), any(), any());
     }
 
     @DisplayName("latitude 파라미터 없이 요청하면 400을 반환한다")
@@ -127,6 +131,6 @@ class PloggingAnalysisControllerTest {
                         .param("longitude", "127.0"))
                 .andExpect(status().isInternalServerError());
 
-        verify(ploggingAnalysisService, never()).analyzeAsync(any(), any(), any(), any());
+        verify(ploggingAnalysisService, never()).analyzeAsync(any(), any(), any(), any(), any());
     }
 }

--- a/src/test/java/com/flover/flover_be/plogging/service/PloggingAnalysisServiceTest.java
+++ b/src/test/java/com/flover/flover_be/plogging/service/PloggingAnalysisServiceTest.java
@@ -10,11 +10,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +36,7 @@ class PloggingAnalysisServiceTest {
 
     @Mock private RestClient restClient;
     @Mock private TrashDetectionRepository trashDetectionRepository;
+    @Mock private ObjectProvider<JdbcTemplate> postgresJdbcTemplateProvider;
 
     private PloggingAnalysisService service;
 
@@ -44,11 +48,12 @@ class PloggingAnalysisServiceTest {
     private static final String FILENAME = "trash.jpg";
     private static final Double LATITUDE = 37.5;
     private static final Double LONGITUDE = 127.0;
+    private static final LocalDateTime REPORTED_AT = LocalDateTime.of(2026, 5, 28, 12, 0);
 
     @BeforeEach
     void setUp() {
         service = new PloggingAnalysisService(
-                restClient, trashDetectionRepository,
+                restClient, trashDetectionRepository, postgresJdbcTemplateProvider,
                 "http://ai-test/predict", "test-api-key"
         );
 
@@ -77,7 +82,7 @@ class PloggingAnalysisServiceTest {
         given(responseSpec.body(AiResponseDto.class)).willReturn(response);
 
         // when
-        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE);
+        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
         ArgumentCaptor<List<TrashDetection>> captor = ArgumentCaptor.forClass(List.class);
@@ -109,7 +114,7 @@ class PloggingAnalysisServiceTest {
         given(responseSpec.body(AiResponseDto.class)).willReturn(response);
 
         // when
-        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE);
+        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
         ArgumentCaptor<List<TrashDetection>> captor = ArgumentCaptor.forClass(List.class);
@@ -136,7 +141,7 @@ class PloggingAnalysisServiceTest {
         given(responseSpec.body(AiResponseDto.class)).willReturn(response);
 
         // when
-        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE);
+        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
         ArgumentCaptor<List<TrashDetection>> captor = ArgumentCaptor.forClass(List.class);
@@ -157,7 +162,7 @@ class PloggingAnalysisServiceTest {
         given(responseSpec.body(AiResponseDto.class)).willReturn(response);
 
         // when
-        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE);
+        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
         ArgumentCaptor<List<TrashDetection>> captor = ArgumentCaptor.forClass(List.class);
@@ -173,7 +178,7 @@ class PloggingAnalysisServiceTest {
                 .willThrow(new RestClientException("AI 서버 연결 거부"));
 
         // when
-        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE);
+        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
         verify(trashDetectionRepository, never()).saveAll(any());
@@ -191,7 +196,7 @@ class PloggingAnalysisServiceTest {
         given(responseSpec.body(AiResponseDto.class)).willReturn(failResponse);
 
         // when
-        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE);
+        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
         verify(trashDetectionRepository, never()).saveAll(any());
@@ -204,7 +209,7 @@ class PloggingAnalysisServiceTest {
         given(responseSpec.body(AiResponseDto.class)).willReturn(null);
 
         // when
-        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE);
+        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
         verify(trashDetectionRepository, never()).saveAll(any());
@@ -222,7 +227,7 @@ class PloggingAnalysisServiceTest {
         given(responseSpec.body(AiResponseDto.class)).willReturn(response);
 
         // when
-        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE);
+        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
         verify(postBodySpec).header("X-API-Key", "test-api-key");
@@ -240,7 +245,7 @@ class PloggingAnalysisServiceTest {
         given(responseSpec.body(AiResponseDto.class)).willReturn(response);
 
         // when
-        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE);
+        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
         ArgumentCaptor<List<TrashDetection>> captor = ArgumentCaptor.forClass(List.class);
@@ -256,7 +261,7 @@ class PloggingAnalysisServiceTest {
                 .willThrow(new RuntimeException("예상치 못한 오류"));
 
         // when
-        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE);
+        service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
         verify(trashDetectionRepository, never()).saveAll(any());


### PR DESCRIPTION
  ## 관련 이슈                                                                                
                                                           
  ## 작업 내용                                             
  - PostgreSQL RDS에 접근하기 위한 별도 datasource 설정을 추가했습니다.                                            
  - 쓰레기 이미지 추론 결과 저장 시 기존 MySQL `trash_detections` 저장 이후 PostgreSQL `raw_trash_reports`에도 함께 저장하도록 구현했습니다.    
  - PostgreSQL 저장 데이터는 감지 결과 1건당 1건씩 생성됩니다.
    - `source_id`: `trash_detection:{MySQL trash_detections.id}`                                    
    - `provider`: `plover`                                 
    - `reported_at`: 제보 요청 시각                        
    - `geometry`: `ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)`                                        
  - CI/CD 배포 시 필요한 PostgreSQL 환경변수 4개를 `deploy.yml`에 추가했습니다.                             
    - `POSTGRES_DB_ENABLED`                                
    - `POSTGRES_DB_URL`                                    
    - `POSTGRES_DB_USERNAME`                               
    - `POSTGRES_DB_PASSWORD`                               
  - 변경된 `analyzeAsync` 시그니처에 맞춰 관련 테스트 코드를 수정했습니다.                                         
                                                           
  ## 테스트                                                
  - [x] 로컬에서 정상 동작을 확인했습니다.                 
  - [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.       

## 체크리스트
- [X] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [X] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [X] 머지 전 스스로 한 번 더 확인했습니다.
