### PR TITLE
fix: Swagger Https CORS 설정

### DIFF
--- a/src/main/java/com/plover/plover_be/global/config/SwaggerConfig.java
+++ b/src/main/java/com/plover/plover_be/global/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.plover.plover_be.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,6 +12,12 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
+                .addServersItem(new Server()
+                        .url("https://moong.co.kr")
+                        .description("Production Server"))
+                .addServersItem(new Server()
+                        .url("http://localhost:8080")
+                        .description("Local Server"))
                 .info(new Info()
                         .title("Plover API")
                         .version("v1.0")

--- a/src/main/java/com/plover/plover_be/global/config/WebConfig.java
+++ b/src/main/java/com/plover/plover_be/global/config/WebConfig.java
@@ -20,7 +20,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:3000")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "http://localhost:8080",
+                        "https://moong.co.kr"
+                )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(false)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,3 +44,5 @@ aws.credentials.secret-key=${AWS_SECRET_ACCESS_KEY:}
 # Multipart
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=5MB
+
+server.forward-headers-strategy=framework


### PR DESCRIPTION
## 관련 이슈
- close # (이슈 번호)

## 작업 내용
- 스웨거 돌려보다가 서버는 HTTPS인데, 스웨거에서는 HTTP로 요청 보내서 CORS 에러 터지는 것 수정했습니다.

## 테스트
- [X] 로컬에서 정상 동작을 확인했습니다.
- [X] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [X] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [X] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [X] 머지 전 스스로 한 번 더 확인했습니다.
