### PR TITLE
refactor: 분석 결과가 비어있을 시 DB에 저장하지 않도록 수정

### DIFF
--- a/src/main/java/com/plover/plover_be/plogging/service/PloggingAnalysisService.java
+++ b/src/main/java/com/plover/plover_be/plogging/service/PloggingAnalysisService.java
@@ -102,6 +102,11 @@ public class PloggingAnalysisService {
                 ))
                 .toList();
 
+        if (detections.isEmpty()) {
+            log.info("쓰레기 감지 결과 없음: 저장 생략");
+            return;
+        }
+
         List<TrashDetection> savedDetections = trashDetectionRepository.saveAll(detections);
         saveRawTrashReports(savedDetections, reportedAt);
         log.info("쓰레기 감지 결과 저장 완료: {}건", detections.size());

--- a/src/test/java/com/plover/plover_be/plogging/service/PloggingAnalysisServiceTest.java
+++ b/src/test/java/com/plover/plover_be/plogging/service/PloggingAnalysisServiceTest.java
@@ -233,9 +233,9 @@ class PloggingAnalysisServiceTest {
         verify(postBodySpec).header("X-API-Key", "test-api-key");
     }
 
-    @DisplayName("감지 항목이 없으면 빈 리스트를 저장한다")
+    @DisplayName("감지 항목이 없으면 저장하지 않는다")
     @Test
-    void analyze_async_감지항목_없으면_빈_리스트_저장() {
+    void analyze_async_감지항목_없으면_저장안함() {
         // given
         AiResponseDto response = new AiResponseDto(
                 "success", 0,
@@ -248,9 +248,7 @@ class PloggingAnalysisServiceTest {
         service.analyzeAsync(IMAGE_BYTES, FILENAME, LATITUDE, LONGITUDE, REPORTED_AT);
 
         // then
-        ArgumentCaptor<List<TrashDetection>> captor = ArgumentCaptor.forClass(List.class);
-        verify(trashDetectionRepository).saveAll(captor.capture());
-        assertThat(captor.getValue()).isEmpty();
+        verify(trashDetectionRepository, never()).saveAll(any());
     }
 
     @DisplayName("예상치 못한 예외 발생 시 DB에 저장하지 않는다")


### PR DESCRIPTION
## 관련 이슈
- close #60 

## 작업 내용
- 추론 결과가 비어있으면 DB에 저장하지 않는 방식으로 리팩토링

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [X] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [X] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [X] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [X] 머지 전 스스로 한 번 더 확인했습니다.
