### PR TITLE
feat: 제보 API 시큐어 코딩

### DIFF
--- a/src/main/java/com/plover/plover_be/plogging/controller/PloggingAnalysisController.java
+++ b/src/main/java/com/plover/plover_be/plogging/controller/PloggingAnalysisController.java
@@ -3,6 +3,7 @@ package com.plover.plover_be.plogging.controller;
 import com.plover.plover_be.plogging.exception.PloggingErrorCode;
 import com.plover.plover_be.plogging.exception.PloggingException;
 import com.plover.plover_be.plogging.service.PloggingAnalysisService;
+import com.plover.plover_be.plogging.service.PloggingImageValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
@@ -26,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class PloggingAnalysisController {
 
     private final PloggingAnalysisService ploggingAnalysisService;
+    private final PloggingImageValidator ploggingImageValidator;
 
     @Operation(summary = "플로깅 이미지 AI 분석",
             description = "플로깅 중 촬영한 이미지를 AI 서버로 전송하여 쓰레기 감지 분석을 비동기로 수행합니다. 분석 결과는 DB에 저장됩니다.")
@@ -36,6 +38,7 @@ public class PloggingAnalysisController {
             @RequestParam Double longitude
     ) {
         try {
+            ploggingImageValidator.validate(image);
             byte[] imageBytes = image.getBytes();
             ploggingAnalysisService.analyzeAsync(imageBytes, image.getOriginalFilename(), latitude, longitude, LocalDateTime.now());
         } catch (IOException e) {

--- a/src/main/java/com/plover/plover_be/plogging/exception/PloggingErrorCode.java
+++ b/src/main/java/com/plover/plover_be/plogging/exception/PloggingErrorCode.java
@@ -10,6 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum PloggingErrorCode implements ErrorCode {
 
     PLOGGING_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "플로깅 세션을 찾을 수 없습니다."),
+    IMAGE_FILE_REQUIRED(HttpStatus.BAD_REQUEST, "이미지 파일은 필수입니다."),
+    IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 파일 크기는 5MB를 초과할 수 없습니다."),
+    INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "지원하지 않거나 손상된 이미지 형식입니다."),
+    IMAGE_PIXEL_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 해상도가 허용 범위를 초과했습니다."),
     IMAGE_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 데이터를 처리하는 중 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/plover/plover_be/plogging/exception/PloggingErrorCode.java
+++ b/src/main/java/com/plover/plover_be/plogging/exception/PloggingErrorCode.java
@@ -11,7 +11,7 @@ public enum PloggingErrorCode implements ErrorCode {
 
     PLOGGING_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "플로깅 세션을 찾을 수 없습니다."),
     IMAGE_FILE_REQUIRED(HttpStatus.BAD_REQUEST, "이미지 파일은 필수입니다."),
-    IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 파일 크기는 5MB를 초과할 수 없습니다."),
+    IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 파일 크기는 10MB를 초과할 수 없습니다."),
     INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "지원하지 않거나 손상된 이미지 형식입니다."),
     IMAGE_PIXEL_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 해상도가 허용 범위를 초과했습니다."),
     IMAGE_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 데이터를 처리하는 중 오류가 발생했습니다.");

--- a/src/main/java/com/plover/plover_be/plogging/service/PloggingImageValidator.java
+++ b/src/main/java/com/plover/plover_be/plogging/service/PloggingImageValidator.java
@@ -1,0 +1,184 @@
+package com.plover.plover_be.plogging.service;
+
+import com.plover.plover_be.plogging.exception.PloggingErrorCode;
+import com.plover.plover_be.plogging.exception.PloggingException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Set;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class PloggingImageValidator {
+
+    private static final long MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024L;
+    private static final long MAX_IMAGE_PIXELS = 20_000_000L;
+
+    public void validate(MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw imageValidationException(PloggingErrorCode.IMAGE_FILE_REQUIRED);
+        }
+
+        if (image.getSize() > MAX_FILE_SIZE_BYTES) {
+            throw imageValidationException(PloggingErrorCode.IMAGE_SIZE_EXCEEDED);
+        }
+
+        ImageFormat contentTypeFormat = ImageFormat.fromContentType(image.getContentType());
+        ImageFormat extensionFormat = ImageFormat.fromFilename(image.getOriginalFilename());
+        if (contentTypeFormat == null || extensionFormat == null || contentTypeFormat != extensionFormat) {
+            throw imageValidationException(PloggingErrorCode.INVALID_IMAGE_FORMAT);
+        }
+
+        validateImageContent(image, contentTypeFormat);
+    }
+
+    private void validateImageContent(MultipartFile image, ImageFormat expectedFormat) {
+        try (InputStream inputStream = image.getInputStream();
+             ImageInputStream imageInputStream = ImageIO.createImageInputStream(inputStream)) {
+            if (imageInputStream == null) {
+                throw imageValidationException(PloggingErrorCode.INVALID_IMAGE_FORMAT);
+            }
+
+            ImageFormat magicNumberFormat = readMagicNumberFormat(imageInputStream);
+            if (magicNumberFormat == null || magicNumberFormat != expectedFormat) {
+                throw imageValidationException(PloggingErrorCode.INVALID_IMAGE_FORMAT);
+            }
+
+            validateImageHeader(imageInputStream, expectedFormat);
+        } catch (PloggingException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new PloggingException(PloggingErrorCode.IMAGE_PROCESSING_FAILED);
+        }
+    }
+
+    private ImageFormat readMagicNumberFormat(ImageInputStream imageInputStream) {
+        try {
+            byte[] header = new byte[8];
+            int bytesRead = imageInputStream.read(header);
+            imageInputStream.seek(0);
+            return ImageFormat.fromMagicNumber(header, Math.max(bytesRead, 0));
+        } catch (IOException e) {
+            throw imageValidationException(PloggingErrorCode.INVALID_IMAGE_FORMAT);
+        }
+    }
+
+    private void validateImageHeader(ImageInputStream imageInputStream, ImageFormat expectedFormat) {
+        try {
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(imageInputStream);
+            if (!readers.hasNext()) {
+                throw imageValidationException(PloggingErrorCode.INVALID_IMAGE_FORMAT);
+            }
+
+            ImageReader reader = readers.next();
+            try {
+                reader.setInput(imageInputStream, true, true);
+                ImageFormat actualFormat = ImageFormat.fromReaderFormatName(reader.getFormatName());
+                int width = reader.getWidth(0);
+                int height = reader.getHeight(0);
+
+                if (actualFormat != expectedFormat || width <= 0 || height <= 0) {
+                    throw imageValidationException(PloggingErrorCode.INVALID_IMAGE_FORMAT);
+                }
+
+                if ((long) width * height > MAX_IMAGE_PIXELS) {
+                    throw imageValidationException(PloggingErrorCode.IMAGE_PIXEL_LIMIT_EXCEEDED);
+                }
+            } finally {
+                reader.dispose();
+            }
+        } catch (IOException e) {
+            throw imageValidationException(PloggingErrorCode.INVALID_IMAGE_FORMAT);
+        }
+    }
+
+    private PloggingException imageValidationException(PloggingErrorCode errorCode) {
+        return new PloggingException(errorCode);
+    }
+
+    private enum ImageFormat {
+        JPEG(Set.of("image/jpeg"), Set.of("jpg", "jpeg")),
+        PNG(Set.of("image/png"), Set.of("png"));
+
+        private final Set<String> contentTypes;
+        private final Set<String> extensions;
+
+        ImageFormat(Set<String> contentTypes, Set<String> extensions) {
+            this.contentTypes = contentTypes;
+            this.extensions = extensions;
+        }
+
+        private static ImageFormat fromContentType(String contentType) {
+            if (contentType == null || contentType.isBlank()) {
+                return null;
+            }
+
+            String normalizedContentType = contentType.toLowerCase(Locale.ROOT);
+            for (ImageFormat format : values()) {
+                if (format.contentTypes.contains(normalizedContentType)) {
+                    return format;
+                }
+            }
+            return null;
+        }
+
+        private static ImageFormat fromFilename(String filename) {
+            if (filename == null || filename.isBlank()) {
+                return null;
+            }
+
+            int extensionStart = filename.lastIndexOf('.');
+            if (extensionStart < 0 || extensionStart == filename.length() - 1) {
+                return null;
+            }
+
+            String extension = filename.substring(extensionStart + 1).toLowerCase(Locale.ROOT);
+            for (ImageFormat format : values()) {
+                if (format.extensions.contains(extension)) {
+                    return format;
+                }
+            }
+            return null;
+        }
+
+        private static ImageFormat fromMagicNumber(byte[] header, int bytesRead) {
+            if (bytesRead >= 3
+                    && (header[0] & 0xFF) == 0xFF
+                    && (header[1] & 0xFF) == 0xD8
+                    && (header[2] & 0xFF) == 0xFF) {
+                return JPEG;
+            }
+
+            if (bytesRead >= 8
+                    && (header[0] & 0xFF) == 0x89
+                    && header[1] == 0x50
+                    && header[2] == 0x4E
+                    && header[3] == 0x47
+                    && header[4] == 0x0D
+                    && header[5] == 0x0A
+                    && header[6] == 0x1A
+                    && header[7] == 0x0A) {
+                return PNG;
+            }
+
+            return null;
+        }
+
+        private static ImageFormat fromReaderFormatName(String formatName) {
+            if (formatName == null) {
+                return null;
+            }
+
+            return switch (formatName.toLowerCase(Locale.ROOT)) {
+                case "jpeg", "jpg" -> JPEG;
+                case "png" -> PNG;
+                default -> null;
+            };
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,7 +42,7 @@ aws.credentials.access-key=${AWS_ACCESS_KEY_ID:}
 aws.credentials.secret-key=${AWS_SECRET_ACCESS_KEY:}
 
 # Multipart
-spring.servlet.multipart.max-file-size=5MB
-spring.servlet.multipart.max-request-size=5MB
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
 
 server.forward-headers-strategy=framework

--- a/src/test/java/com/plover/plover_be/plogging/controller/PloggingAnalysisControllerTest.java
+++ b/src/test/java/com/plover/plover_be/plogging/controller/PloggingAnalysisControllerTest.java
@@ -1,7 +1,10 @@
 package com.plover.plover_be.plogging.controller;
 
 import com.plover.plover_be.global.exception.GlobalExceptionHandler;
+import com.plover.plover_be.plogging.exception.PloggingErrorCode;
+import com.plover.plover_be.plogging.exception.PloggingException;
 import com.plover.plover_be.plogging.service.PloggingAnalysisService;
+import com.plover.plover_be.plogging.service.PloggingImageValidator;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -28,6 +32,9 @@ class PloggingAnalysisControllerTest {
 
     @Mock
     private PloggingAnalysisService ploggingAnalysisService;
+
+    @Mock
+    private PloggingImageValidator ploggingImageValidator;
 
     @InjectMocks
     private PloggingAnalysisController controller;
@@ -76,6 +83,24 @@ class PloggingAnalysisControllerTest {
 
         // then
         verify(ploggingAnalysisService)
+                .analyzeAsync(any(), anyString(), anyDouble(), anyDouble(), any(LocalDateTime.class));
+    }
+
+    @DisplayName("이미지 검증 실패 시 400을 반환하고 분석을 시작하지 않는다")
+    @Test
+    void analyze_image_검증_실패_400_반환() throws Exception {
+        // given
+        doThrow(new PloggingException(PloggingErrorCode.INVALID_IMAGE_FORMAT))
+                .when(ploggingImageValidator).validate(any());
+
+        // when & then
+        mockMvc.perform(multipart("/api/plogging/analyze")
+                        .file(VALID_IMAGE)
+                        .param("latitude", "37.5")
+                        .param("longitude", "127.0"))
+                .andExpect(status().isBadRequest());
+
+        verify(ploggingAnalysisService, never())
                 .analyzeAsync(any(), anyString(), anyDouble(), anyDouble(), any(LocalDateTime.class));
     }
 

--- a/src/test/java/com/plover/plover_be/plogging/service/PloggingImageValidatorTest.java
+++ b/src/test/java/com/plover/plover_be/plogging/service/PloggingImageValidatorTest.java
@@ -1,0 +1,150 @@
+package com.plover.plover_be.plogging.service;
+
+import com.plover.plover_be.plogging.exception.PloggingErrorCode;
+import com.plover.plover_be.plogging.exception.PloggingException;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PloggingImageValidatorTest {
+
+    private static final String FILE_PART_NAME = "image";
+    private static final long MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024L;
+
+    private final PloggingImageValidator validator = new PloggingImageValidator();
+
+    @DisplayName("정상 JPEG 이미지는 검증을 통과한다")
+    @Test
+    void validate_정상_jpeg_통과() throws IOException {
+        // given
+        MockMultipartFile image = new MockMultipartFile(
+                FILE_PART_NAME, "trash.jpg", "image/jpeg", createImageBytes("jpg")
+        );
+
+        // when & then
+        assertThatCode(() -> validator.validate(image))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("정상 PNG 이미지는 검증을 통과한다")
+    @Test
+    void validate_정상_png_통과() throws IOException {
+        // given
+        MockMultipartFile image = new MockMultipartFile(
+                FILE_PART_NAME, "trash.png", "image/png", createImageBytes("png")
+        );
+
+        // when & then
+        assertThatCode(() -> validator.validate(image))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("빈 파일이면 예외가 발생한다")
+    @Test
+    void validate_빈파일_예외() {
+        // given
+        MockMultipartFile image = new MockMultipartFile(
+                FILE_PART_NAME, "trash.jpg", "image/jpeg", new byte[0]
+        );
+
+        // when & then
+        assertImageValidationFails(image, PloggingErrorCode.IMAGE_FILE_REQUIRED);
+    }
+
+    @DisplayName("허용 크기를 초과하면 예외가 발생한다")
+    @Test
+    void validate_크기초과_예외() {
+        // given
+        MockMultipartFile image = new MockMultipartFile(
+                FILE_PART_NAME, "trash.jpg", "image/jpeg", new byte[(int) MAX_FILE_SIZE_BYTES + 1]
+        );
+
+        // when & then
+        assertImageValidationFails(image, PloggingErrorCode.IMAGE_SIZE_EXCEEDED);
+    }
+
+    @DisplayName("허용되지 않은 MIME 타입이면 예외가 발생한다")
+    @Test
+    void validate_mime_타입_예외() throws IOException {
+        // given
+        MockMultipartFile image = new MockMultipartFile(
+                FILE_PART_NAME, "trash.jpg", "application/octet-stream", createImageBytes("jpg")
+        );
+
+        // when & then
+        assertImageValidationFails(image, PloggingErrorCode.INVALID_IMAGE_FORMAT);
+    }
+
+    @DisplayName("허용되지 않은 확장자이면 예외가 발생한다")
+    @Test
+    void validate_확장자_예외() throws IOException {
+        // given
+        MockMultipartFile image = new MockMultipartFile(
+                FILE_PART_NAME, "trash.gif", "image/jpeg", createImageBytes("jpg")
+        );
+
+        // when & then
+        assertImageValidationFails(image, PloggingErrorCode.INVALID_IMAGE_FORMAT);
+    }
+
+    @DisplayName("파일 시그니처가 이미지가 아니면 예외가 발생한다")
+    @Test
+    void validate_magic_number_예외() {
+        // given
+        MockMultipartFile image = new MockMultipartFile(
+                FILE_PART_NAME, "trash.jpg", "image/jpeg", "not-image".getBytes()
+        );
+
+        // when & then
+        assertImageValidationFails(image, PloggingErrorCode.INVALID_IMAGE_FORMAT);
+    }
+
+    @DisplayName("MIME 타입과 실제 이미지 형식이 다르면 예외가 발생한다")
+    @Test
+    void validate_이미지_형식_불일치_예외() throws IOException {
+        // given
+        MockMultipartFile image = new MockMultipartFile(
+                FILE_PART_NAME, "trash.jpg", "image/jpeg", createImageBytes("png")
+        );
+
+        // when & then
+        assertImageValidationFails(image, PloggingErrorCode.INVALID_IMAGE_FORMAT);
+    }
+
+    @DisplayName("이미지 픽셀 수가 제한을 초과하면 예외가 발생한다")
+    @Test
+    void validate_픽셀수_초과_예외() throws IOException {
+        // given
+        MockMultipartFile image = new MockMultipartFile(
+                FILE_PART_NAME, "trash.png", "image/png", createImageBytes("png", 5000, 4001, BufferedImage.TYPE_BYTE_BINARY)
+        );
+
+        // when & then
+        assertImageValidationFails(image, PloggingErrorCode.IMAGE_PIXEL_LIMIT_EXCEEDED);
+    }
+
+    private void assertImageValidationFails(MockMultipartFile image, PloggingErrorCode errorCode) {
+        assertThatThrownBy(() -> validator.validate(image))
+                .isInstanceOf(PloggingException.class)
+                .extracting("errorCode")
+                .isEqualTo(errorCode);
+    }
+
+    private byte[] createImageBytes(String formatName) throws IOException {
+        return createImageBytes(formatName, 10, 10, BufferedImage.TYPE_INT_RGB);
+    }
+
+    private byte[] createImageBytes(String formatName, int width, int height, int imageType) throws IOException {
+        BufferedImage image = new BufferedImage(width, height, imageType);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ImageIO.write(image, formatName, outputStream);
+        return outputStream.toByteArray();
+    }
+}

--- a/src/test/java/com/plover/plover_be/plogging/service/PloggingImageValidatorTest.java
+++ b/src/test/java/com/plover/plover_be/plogging/service/PloggingImageValidatorTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class PloggingImageValidatorTest {
 
     private static final String FILE_PART_NAME = "image";
-    private static final long MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024L;
+    private static final long MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024L;
 
     private final PloggingImageValidator validator = new PloggingImageValidator();
 


### PR DESCRIPTION
## 관련 이슈                                                                                                                                                                                  
  - close #61 
                                                                                                                                                                                                
  ## 작업 내용                                                                                                                                                                                  
  - 쓰레기 제보 이미지 분석 API에서 AI 분석 시작 전 업로드 파일 검증을 수행하도록 추가했습니다.                                                                                                 
  - 빈 파일, 허용 크기 초과, MIME/확장자/파일 시그니처 불일치, 손상된 이미지, 과도한 해상도 이미지를 차단하도록 구현했습니다.                                                                   
  - 이미지 검증 실패 원인을 구분할 수 있도록 플로깅 이미지 관련 에러 코드를 세분화했습니다.                                                                                                     
  - multipart 업로드 제한을 10MB로 조정했습니다.                                                                                                                                                
  - 감지 결과가 없는 경우 MySQL 저장 호출이 발생하지 않도록 기존 처리 흐름을 유지했습니다.                                                                                                      
                                                                                                                                                                                                
  ## 테스트                                                                                                                                                                                     
  - [x] 로컬에서 정상 동작을 확인했습니다.                                                                                                                                                      
  - [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [X] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [X] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [X] 머지 전 스스로 한 번 더 확인했습니다.
