### PR TITLE
feat: k6 부하 테스팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,9 @@ out/
 !.env.example
 docker-compose.override.yml
 
+### k6 ###
+k6/results/*
+!k6/results/.gitignore
+
 ### Claude ###
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ docker-compose.override.yml
 ### k6 ###
 k6/results/*
 !k6/results/.gitignore
+k6/data/sample-trash-image.jpg
 
 ### Claude ###
 .claude/

--- a/k6/README.md
+++ b/k6/README.md
@@ -1,0 +1,190 @@
+# k6 부하 테스트 가이드
+
+이 구성은 로컬 PC에서 k6를 실행하고, EC2에 배포된 Spring Boot API를 대상으로 요청을 보내는 방식입니다. t2.micro급 인스턴스와 실제 사용자 10명 미만이라는 조건을 고려해 기본 테스트는 읽기 중심, 낮은 VU에서 점진 증가, 쓰기/AI API는 명시적으로 분리했습니다.
+
+## 디렉터리 구조
+
+```text
+k6/
+  data/
+    locations.json
+  results/
+    .gitignore
+  scenarios/
+    smoke-test.js
+    load-test.js
+    stress-test.js
+    ai-analysis-smoke-test.js
+    common.js
+    summary.js
+  README.md
+```
+
+## API 선별 및 우선순위
+
+| 우선순위 | API | 이유 | 기본 실행 |
+| --- | --- | --- | --- |
+| P0 | `GET /api/facilities/trash-bins` | 위치 기반 시설 조회, MySQL 거리 계산 쿼리 | 포함 |
+| P0 | `GET /api/facilities/toilets` | 위치 기반 시설 조회, MySQL 거리 계산 쿼리 | 포함 |
+| P0 | `GET /api/v1/routes` | 경로 추천, 외부 route engine 호출 및 재시도 | 포함, 낮은 비중 |
+| P0 | `GET /api/users/me` | 앱 진입 후 자주 호출되는 인증 사용자 조회 | `ACCESS_TOKEN` 있을 때 포함 |
+| P0 | `GET /api/users/me/plogging-stats` | 마이페이지 핵심 통계 집계 | `ACCESS_TOKEN` 있을 때 포함 |
+| P0 | `GET /api/plogging-sessions` | 활동 기록 목록 조회 | `ACCESS_TOKEN` 있을 때 포함 |
+| P0 | `GET /api/plogging-sessions/monthly` | 월간 통계 집계 | `ACCESS_TOKEN` 있을 때 포함 |
+| P0 | `GET /api/plogging-sessions/weekly` | 주간 통계 집계 | `ACCESS_TOKEN` 있을 때 포함 |
+| P0 | `POST /api/plogging-sessions/complete` | 세션/경로/사진 insert, 사용자 경험치 update | `INCLUDE_WRITE=true`일 때만 포함 |
+| P1 | `GET /api/plogging-sessions/{id}` | 상세 조회, 사진 목록 추가 조회 | `PLOGGING_SESSION_ID` 있을 때 포함 |
+| P1 | `GET /api/users/me/profile-image/upload-url` | S3 presigned URL 발급 | smoke에만 포함 |
+| P1 | `GET /api/plogging-sessions/map-image/upload-url` | S3 presigned URL 발급 | smoke에만 포함 |
+| P1 | `GET /api/plogging-sessions/photo/upload-url` | S3 presigned URL 발급 | smoke에만 포함 |
+| P1 | `POST /api/plogging/analyze` | multipart 이미지 처리, 외부 AI API, MySQL/PostgreSQL 저장 가능 | 별도 `ai-analysis-smoke-test.js` |
+| P2 | `POST /api/auth/kakao/login`, `POST /api/auth/v2/kakao/login`, `POST /api/auth/apple/login` | OAuth 외부 인증 의존, 테스트 토큰 확보가 더 안정적 | 제외 |
+| P2 | `POST /api/auth/logout` | 서버 상태 변경 없음, 성능 병목 가능성 낮음 | 제외 |
+| P2 | `PUT /api/users/me/nickname` | 운영 사용자 닉네임 오염 위험 | 제외 |
+| P2 | `PUT /api/users/me/profile-image` | 운영 프로필 변경 및 S3 삭제 가능성 | 제외 |
+| P2 | `DELETE /api/users/me` | 계정 및 연관 데이터 삭제 | 제외 |
+
+인증은 `Authorization: Bearer <ACCESS_TOKEN>` 방식입니다. 현재 코드에는 email/password 로그인이 없고 Kakao/Apple OAuth만 있으므로, k6 스크립트는 자동 로그인 대신 `ACCESS_TOKEN` 환경변수를 사용합니다.
+
+## k6 설치
+
+Windows PowerShell:
+
+```powershell
+winget install k6 --source winget
+k6 version
+```
+
+Chocolatey 사용 시:
+
+```powershell
+choco install k6
+k6 version
+```
+
+macOS:
+
+```bash
+brew install k6
+k6 version
+```
+
+## 환경변수
+
+PowerShell에서 저장소 루트 기준으로 설정합니다.
+
+```powershell
+$env:BASE_URL = "https://api.example.com"
+$env:ACCESS_TOKEN = "발급받은_JWT"
+$env:TEST_DATA_PREFIX = "k6-test-20260607"
+$env:STATS_YEAR = "2026"
+$env:STATS_MONTH = "6"
+$env:WEEK_START_DATE = "2026-06-01"
+$env:PLOGGING_SESSION_ID = "1"
+```
+
+선택 변수:
+
+| 변수 | 설명 | 기본값 |
+| --- | --- | --- |
+| `BASE_URL` | 테스트 대상 서버 URL. 필수 | 없음 |
+| `ACCESS_TOKEN` | 인증 API 호출용 JWT | 없음 |
+| `TEST_USER_EMAIL` | 현재 스크립트에서는 사용하지 않음. 테스트 계정 추적용 메모 변수 | 없음 |
+| `TEST_USER_PASSWORD` | 현재 스크립트에서는 사용하지 않음. email/password 로그인 도입 시 사용 가능 | 없음 |
+| `TEST_DATA_PREFIX` | 쓰기 테스트 데이터 식별 prefix | `k6-test` |
+| `INCLUDE_WRITE` | `true`일 때만 `POST /complete` 호출 | `false` |
+| `PLOGGING_SESSION_ID` | 상세 조회 대상 세션 ID | 없음 |
+| `ROUTE_TIME_MINUTES` | 경로 추천 요청 시간 | `30` |
+| `ROUTE_MODE` | route engine 전달 mode | `PLOGGING` |
+| `IMAGE_CONTENT_TYPE` | presigned URL 발급 smoke 테스트 content type | `image/png` |
+
+## 실행 명령
+
+smoke test: 1 VU로 API 정상 호출 여부를 확인합니다.
+
+```powershell
+k6 run k6/scenarios/smoke-test.js
+```
+
+load test: t2.micro 기준 보수적으로 1 -> 5 -> 10 -> 20 -> 30 VU까지 올립니다.
+
+```powershell
+k6 run k6/scenarios/load-test.js
+```
+
+stress test: 임계점을 찾기 위해 10 -> 20 -> 30 -> 50 VU까지 올립니다. 기본 구성에서는 100 VU를 사용하지 않습니다.
+
+```powershell
+k6 run k6/scenarios/stress-test.js
+```
+
+쓰기 API를 포함하려면 반드시 테스트 계정과 테스트 데이터 prefix를 확인한 뒤 실행합니다.
+
+```powershell
+$env:INCLUDE_WRITE = "true"
+$env:TEST_DATA_PREFIX = "k6-test-20260607"
+k6 run k6/scenarios/smoke-test.js
+Remove-Item Env:INCLUDE_WRITE
+```
+
+AI 분석 API는 일반 load/stress에서 분리되어 있습니다. `k6/data/sample-trash-image.jpg` 같은 테스트 이미지를 직접 둔 뒤 실행합니다.
+
+```powershell
+$env:RUN_HEAVY_API = "true"
+$env:AI_IMAGE_PATH = "../data/sample-trash-image.jpg"
+k6 run k6/scenarios/ai-analysis-smoke-test.js
+Remove-Item Env:RUN_HEAVY_API
+```
+
+`AI_IMAGE_PATH`는 `ai-analysis-smoke-test.js` 파일 기준 상대 경로로 지정합니다.
+
+## 결과 저장
+
+각 스크립트는 종료 시 자동으로 결과를 저장합니다.
+
+```text
+k6/results/smoke-summary.json
+k6/results/smoke-summary.html
+k6/results/load-summary.json
+k6/results/load-summary.html
+k6/results/stress-summary.json
+k6/results/stress-summary.html
+```
+
+k6 기본 JSON export도 같이 남기고 싶다면 다음처럼 실행할 수 있습니다.
+
+```powershell
+k6 run --summary-export k6/results/load-summary-export.json k6/scenarios/load-test.js
+```
+
+## 지표 해석
+
+`http_req_failed`는 HTTP 요청 실패율입니다. 기본 load 테스트에서는 1% 미만을 목표로 잡았습니다. 0.01은 1%를 의미합니다.
+
+`http_req_duration`은 요청 전체 응답 시간입니다. p95는 전체 요청 중 95%가 이 시간 이내에 끝났다는 뜻이고, p99는 상위 1%의 느린 요청까지 보는 지표입니다.
+
+`http_reqs`의 `rate`가 TPS 또는 RPS에 해당합니다. 예를 들어 `http_reqs rate = 18.5/s`라면 초당 약 18.5개의 HTTP 요청을 처리한 것입니다.
+
+VU 단계별로 `http_req_failed`가 증가하거나 p95/p99가 급격히 증가하는 구간이 한계 후보입니다. 예: “20 VU까지 실패율 0%, p95 420ms였으나 30 VU부터 p95가 1.8s로 상승해 t2.micro 환경의 안정 처리 구간은 20~30 VU 사이로 추정됩니다.”
+
+route API만 느리다면 `api=route_recommendation` 태그의 응답 시간을 따로 봅니다. 이 경우 Spring Boot 자체보다 route engine 또는 네트워크 호출이 병목일 가능성이 큽니다.
+
+쓰기 API를 포함한 경우 `api=plogging_complete_write` 지표를 읽습니다. 실패율이 낮아도 DB에 테스트 세션이 남기 때문에 운영 데이터와 분리된 테스트 계정으로만 실행해야 합니다.
+
+## 테스트 주의사항
+
+삭제 API(`DELETE /api/users/me`)는 기본 테스트에서 제외했습니다.
+
+프로필 이미지 변경 API(`PUT /api/users/me/profile-image`)는 기존 S3 객체 삭제가 발생할 수 있어 제외했습니다.
+
+닉네임 변경 API(`PUT /api/users/me/nickname`)는 운영 사용자 프로필 오염 위험이 있어 제외했습니다.
+
+AI 분석 API는 외부 AI 서버 호출과 DB 저장이 발생하므로 일반 load/stress에 넣지 않았습니다.
+
+쓰기 테스트는 `INCLUDE_WRITE=true`가 없으면 실행되지 않습니다. 실행 시 `TEST_DATA_PREFIX`를 설정하고 테스트 계정으로만 수행합니다.
+
+EC2 t2.micro는 CPU credit 영향을 크게 받습니다. 같은 VU에서도 테스트 시간대와 CPU credit 잔량에 따라 결과가 달라질 수 있으므로 smoke -> load -> stress 순서로 실행하고, 운영 피크 시간에는 stress를 피합니다.
+
+## 발표용 요약 문장
+
+“전체 API를 무작정 호출하지 않고, 위치 기반 조회, 사용자/플로깅 통계, 경로 추천, 세션 완료 쓰기처럼 실제 사용자 흐름과 병목 가능성이 높은 API를 선별했다. t2.micro 환경을 고려해 기본 부하는 30 VU, stress는 50 VU까지 보수적으로 증가시켰고, 삭제/프로필 변경/AI 분석은 운영 데이터 오염과 외부 의존성 위험 때문에 기본 부하 테스트에서 분리했다.”

--- a/k6/README.md
+++ b/k6/README.md
@@ -131,12 +131,11 @@ AI 분석 API는 일반 load/stress에서 분리되어 있습니다. `k6/data/sa
 
 ```powershell
 $env:RUN_HEAVY_API = "true"
-$env:AI_IMAGE_PATH = "../data/sample-trash-image.jpg"
 k6 run k6/scenarios/ai-analysis-smoke-test.js
 Remove-Item Env:RUN_HEAVY_API
 ```
 
-`AI_IMAGE_PATH`는 `ai-analysis-smoke-test.js` 파일 기준 상대 경로로 지정합니다.
+AI 분석 테스트 이미지는 반드시 `k6/data/sample-trash-image.jpg` 경로에 JPEG 파일로 둡니다. k6의 `open()`은 init context에서 실행되므로 동적 환경변수 경로 대신 스크립트 안의 정적 문자열 리터럴 경로를 사용합니다.
 
 ## 결과 저장
 

--- a/k6/data/locations.json
+++ b/k6/data/locations.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "seoul_city_hall",
+    "lat": 37.5665,
+    "lng": 126.9780
+  },
+  {
+    "name": "gangnam_station",
+    "lat": 37.4979,
+    "lng": 127.0276
+  },
+  {
+    "name": "hongdae",
+    "lat": 37.5572,
+    "lng": 126.9254
+  },
+  {
+    "name": "gwangju_chonnam_univ",
+    "lat": 35.1769,
+    "lng": 126.9058
+  }
+]

--- a/k6/results/.gitignore
+++ b/k6/results/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+k6/results

--- a/k6/scenarios/ai-analysis-smoke-test.js
+++ b/k6/scenarios/ai-analysis-smoke-test.js
@@ -7,10 +7,9 @@ if ((__ENV.RUN_HEAVY_API || 'false').toLowerCase() !== 'true') {
   throw new Error('AI analysis test is disabled. Set RUN_HEAVY_API=true to call the external AI API.');
 }
 
-const imagePath = __ENV.AI_IMAGE_PATH || '../data/sample-trash-image.jpg';
-const imageName = __ENV.AI_IMAGE_NAME || 'k6-ai-test.jpg';
-const imageContentType = __ENV.AI_IMAGE_CONTENT_TYPE || 'image/jpeg';
-const imageBytes = open(imagePath, 'b');
+const imageName = 'sample-trash-image.jpg';
+const imageContentType = 'image/jpeg';
+const imageBytes = open('../data/sample-trash-image.jpg', 'b');
 
 export const options = {
   summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],

--- a/k6/scenarios/ai-analysis-smoke-test.js
+++ b/k6/scenarios/ai-analysis-smoke-test.js
@@ -1,0 +1,48 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { buildSummary } from './summary.js';
+import { config } from './common.js';
+
+if ((__ENV.RUN_HEAVY_API || 'false').toLowerCase() !== 'true') {
+  throw new Error('AI analysis test is disabled. Set RUN_HEAVY_API=true to call the external AI API.');
+}
+
+const imagePath = __ENV.AI_IMAGE_PATH || '../data/sample-trash-image.jpg';
+const imageName = __ENV.AI_IMAGE_NAME || 'k6-ai-test.jpg';
+const imageContentType = __ENV.AI_IMAGE_CONTENT_TYPE || 'image/jpeg';
+const imageBytes = open(imagePath, 'b');
+
+export const options = {
+  summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+  vus: 1,
+  duration: '30s',
+  thresholds: {
+    checks: ['rate>0.95'],
+    http_req_failed: ['rate<0.01'],
+    'http_req_duration{type:heavy}': ['p(95)<3000'],
+  },
+};
+
+export default function () {
+  const params = {
+    tags: { api: 'plogging_analyze', priority: 'P1', type: 'heavy' },
+  };
+  const body = {
+    image: http.file(imageBytes, imageName, imageContentType),
+  };
+  const res = http.post(
+    `${config.baseUrl}/api/plogging/analyze?latitude=37.5665&longitude=126.9780`,
+    body,
+    params
+  );
+
+  check(res, {
+    'AI analyze status is 200': (r) => r.status === 200,
+  });
+
+  sleep(10);
+}
+
+export function handleSummary(data) {
+  return buildSummary(data, 'ai-analysis-smoke');
+}

--- a/k6/scenarios/common.js
+++ b/k6/scenarios/common.js
@@ -1,0 +1,331 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { SharedArray } from 'k6/data';
+
+const locations = new SharedArray('locations', () => JSON.parse(open('../data/locations.json')));
+
+export const config = {
+  baseUrl: (__ENV.BASE_URL || '').replace(/\/$/, ''),
+  accessToken: __ENV.ACCESS_TOKEN || '',
+  includeWrite: (__ENV.INCLUDE_WRITE || 'false').toLowerCase() === 'true',
+  testDataPrefix: __ENV.TEST_DATA_PREFIX || 'k6-test',
+  testUserEmail: __ENV.TEST_USER_EMAIL || '',
+  testUserPassword: __ENV.TEST_USER_PASSWORD || '',
+  sleepSeconds: Number(__ENV.SLEEP_SECONDS || '1'),
+  statsYear: Number(__ENV.STATS_YEAR || new Date().getFullYear()),
+  statsMonth: Number(__ENV.STATS_MONTH || (new Date().getMonth() + 1)),
+  weekStartDate: __ENV.WEEK_START_DATE || '2026-06-01',
+  ploggingSessionId: __ENV.PLOGGING_SESSION_ID || '',
+  routeTimeMinutes: Number(__ENV.ROUTE_TIME_MINUTES || '30'),
+  routeMode: __ENV.ROUTE_MODE || 'PLOGGING',
+  contentType: __ENV.IMAGE_CONTENT_TYPE || 'image/png',
+};
+
+if (!config.baseUrl) {
+  throw new Error('BASE_URL is required. Example: $env:BASE_URL = "https://api.example.com"');
+}
+
+let missingTokenWarned = false;
+
+function randomLocation() {
+  return locations[Math.floor(Math.random() * locations.length)];
+}
+
+function randomSuffix() {
+  return `${Date.now()}-${__VU}-${__ITER}`;
+}
+
+function query(params) {
+  return Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&');
+}
+
+function url(path, params = {}) {
+  const qs = query(params);
+  return `${config.baseUrl}${path}${qs ? `?${qs}` : ''}`;
+}
+
+function commonHeaders(extra = {}) {
+  return {
+    ...extra,
+  };
+}
+
+function authHeaders(extra = {}) {
+  return commonHeaders({
+    Authorization: `Bearer ${config.accessToken}`,
+    ...extra,
+  });
+}
+
+function requestParams(tags, headers = {}) {
+  return {
+    headers,
+    tags,
+  };
+}
+
+function parseJson(res) {
+  try {
+    return res.json();
+  } catch (_) {
+    return null;
+  }
+}
+
+function hasAccessToken(apiName) {
+  if (config.accessToken) {
+    return true;
+  }
+
+  if (!missingTokenWarned) {
+    console.warn(`ACCESS_TOKEN is missing. Skipping authenticated k6 requests such as ${apiName}.`);
+    missingTokenWarned = true;
+  }
+  return false;
+}
+
+export function thinkTime(multiplier = 1) {
+  sleep(Math.max(config.sleepSeconds * multiplier, 0.1));
+}
+
+export function getNearbyTrashBins() {
+  const loc = randomLocation();
+  const res = http.get(
+    url('/api/facilities/trash-bins', { lat: loc.lat, lng: loc.lng }),
+    requestParams({ api: 'facility_trash_bins', priority: 'P0', type: 'read' })
+  );
+  const body = parseJson(res);
+
+  check(res, {
+    'trash bins status is 200': (r) => r.status === 200,
+    'trash bins response is array': () => Array.isArray(body),
+  });
+}
+
+export function getNearbyToilets() {
+  const loc = randomLocation();
+  const res = http.get(
+    url('/api/facilities/toilets', { lat: loc.lat, lng: loc.lng }),
+    requestParams({ api: 'facility_toilets', priority: 'P0', type: 'read' })
+  );
+  const body = parseJson(res);
+
+  check(res, {
+    'toilets status is 200': (r) => r.status === 200,
+    'toilets response is array': () => Array.isArray(body),
+  });
+}
+
+export function getRouteRecommendation() {
+  const loc = randomLocation();
+  const res = http.get(
+    url('/api/v1/routes', {
+      lat: loc.lat,
+      lon: loc.lng,
+      time: config.routeTimeMinutes,
+      mode: config.routeMode,
+    }),
+    requestParams({ api: 'route_recommendation', priority: 'P0', type: 'route' })
+  );
+  const body = parseJson(res);
+
+  check(res, {
+    'route status is 200': (r) => r.status === 200,
+    'route response has routes array': () => body !== null && Array.isArray(body.routes),
+  });
+}
+
+export function getMyInfo() {
+  if (!hasAccessToken('getMyInfo')) {
+    return;
+  }
+
+  const res = http.get(
+    url('/api/users/me'),
+    requestParams({ api: 'user_me', priority: 'P0', type: 'read' }, authHeaders())
+  );
+  const body = parseJson(res);
+
+  check(res, {
+    'my info status is 200': (r) => r.status === 200,
+    'my info has nickname': () => body !== null && Object.prototype.hasOwnProperty.call(body, 'nickname'),
+  });
+}
+
+export function getMyPloggingStats() {
+  if (!hasAccessToken('getMyPloggingStats')) {
+    return;
+  }
+
+  const res = http.get(
+    url('/api/users/me/plogging-stats'),
+    requestParams({ api: 'user_plogging_stats', priority: 'P0', type: 'read' }, authHeaders())
+  );
+  const body = parseJson(res);
+
+  check(res, {
+    'my plogging stats status is 200': (r) => r.status === 200,
+    'my plogging stats has count': () => body !== null && Object.prototype.hasOwnProperty.call(body, 'totalPloggingCount'),
+  });
+}
+
+export function listPloggingSessions() {
+  if (!hasAccessToken('listPloggingSessions')) {
+    return;
+  }
+
+  const res = http.get(
+    url('/api/plogging-sessions', { page: 0, size: 20 }),
+    requestParams({ api: 'plogging_session_list', priority: 'P0', type: 'read' }, authHeaders())
+  );
+  const body = parseJson(res);
+
+  check(res, {
+    'session list status is 200': (r) => r.status === 200,
+    'session list has content': () => body !== null && Array.isArray(body.content),
+  });
+}
+
+export function getMonthlyStats() {
+  if (!hasAccessToken('getMonthlyStats')) {
+    return;
+  }
+
+  const res = http.get(
+    url('/api/plogging-sessions/monthly', {
+      year: config.statsYear,
+      month: config.statsMonth,
+    }),
+    requestParams({ api: 'plogging_monthly_stats', priority: 'P0', type: 'read' }, authHeaders())
+  );
+  const body = parseJson(res);
+
+  check(res, {
+    'monthly stats status is 200': (r) => r.status === 200,
+    'monthly stats has total count': () => body !== null && Object.prototype.hasOwnProperty.call(body, 'totalPloggingCount'),
+  });
+}
+
+export function getWeeklyStats() {
+  if (!hasAccessToken('getWeeklyStats')) {
+    return;
+  }
+
+  const res = http.get(
+    url('/api/plogging-sessions/weekly', { startDate: config.weekStartDate }),
+    requestParams({ api: 'plogging_weekly_stats', priority: 'P0', type: 'read' }, authHeaders())
+  );
+  const body = parseJson(res);
+
+  check(res, {
+    'weekly stats status is 200': (r) => r.status === 200,
+    'weekly stats has daily stats': () => body !== null && Array.isArray(body.dailyStats),
+  });
+}
+
+export function getPloggingSessionDetail() {
+  if (!config.ploggingSessionId || !hasAccessToken('getPloggingSessionDetail')) {
+    return;
+  }
+
+  const res = http.get(
+    url(`/api/plogging-sessions/${config.ploggingSessionId}`),
+    requestParams({ api: 'plogging_session_detail', priority: 'P1', type: 'read' }, authHeaders())
+  );
+  const body = parseJson(res);
+
+  check(res, {
+    'session detail status is 200': (r) => r.status === 200,
+    'session detail has id': () => body !== null && Object.prototype.hasOwnProperty.call(body, 'ploggingSessionId'),
+  });
+}
+
+export function getUploadUrlsSmoke() {
+  if (!hasAccessToken('getUploadUrlsSmoke')) {
+    return;
+  }
+
+  const endpoints = [
+    {
+      name: 'profile_image_upload_url',
+      path: '/api/users/me/profile-image/upload-url',
+      priority: 'P1',
+    },
+    {
+      name: 'map_image_upload_url',
+      path: '/api/plogging-sessions/map-image/upload-url',
+      priority: 'P1',
+    },
+    {
+      name: 'photo_upload_url',
+      path: '/api/plogging-sessions/photo/upload-url',
+      priority: 'P1',
+    },
+  ];
+
+  for (const endpoint of endpoints) {
+    const res = http.get(
+      url(endpoint.path, { contentType: config.contentType }),
+      requestParams({ api: endpoint.name, priority: endpoint.priority, type: 'presigned_url' }, authHeaders())
+    );
+    const body = parseJson(res);
+
+    check(res, {
+      [`${endpoint.name} status is 200`]: (r) => r.status === 200,
+      [`${endpoint.name} has upload url`]: () => body !== null && Object.prototype.hasOwnProperty.call(body, 'uploadUrl'),
+    });
+  }
+}
+
+export function completePloggingWrite() {
+  if (!config.includeWrite || !hasAccessToken('completePloggingWrite')) {
+    return;
+  }
+
+  const loc = randomLocation();
+  const suffix = randomSuffix();
+  const now = new Date();
+  const startedAt = new Date(now.getTime() - 10 * 60 * 1000).toISOString().slice(0, 19);
+  const finishedAt = now.toISOString().slice(0, 19);
+
+  const payload = {
+    mode: 'FREE',
+    startedAt,
+    finishedAt,
+    distanceMeters: 1200,
+    stepCount: 1800,
+    caloriesBurned: 70,
+    ploggingSeconds: 600,
+    restSeconds: 0,
+    placeName: `${config.testDataPrefix}-place-${suffix}`,
+    startLatitude: loc.lat,
+    startLongitude: loc.lng,
+    endLatitude: loc.lat + 0.002,
+    endLongitude: loc.lng + 0.002,
+    routePoints: [
+      { latitude: loc.lat, longitude: loc.lng },
+      { latitude: loc.lat + 0.001, longitude: loc.lng + 0.001 },
+      { latitude: loc.lat + 0.002, longitude: loc.lng + 0.002 },
+    ],
+    mapImageUrl: `https://example.com/${config.testDataPrefix}/map-${suffix}.png`,
+    photoUrls: [`https://example.com/${config.testDataPrefix}/photo-${suffix}.jpg`],
+  };
+
+  const res = http.post(
+    url('/api/plogging-sessions/complete'),
+    JSON.stringify(payload),
+    requestParams(
+      { api: 'plogging_complete_write', priority: 'P0', type: 'write' },
+      authHeaders({ 'Content-Type': 'application/json' })
+    )
+  );
+  const body = parseJson(res);
+
+  check(res, {
+    'complete plogging status is 200': (r) => r.status === 200,
+    'complete plogging has session id': () => body !== null && Object.prototype.hasOwnProperty.call(body, 'ploggingSessionId'),
+  });
+}

--- a/k6/scenarios/common.js
+++ b/k6/scenarios/common.js
@@ -1,6 +1,7 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 import { SharedArray } from 'k6/data';
+import exec from 'k6/execution';
 
 const locations = new SharedArray('locations', () => JSON.parse(open('../data/locations.json')));
 
@@ -32,7 +33,7 @@ function randomLocation() {
 }
 
 function randomSuffix() {
-  return `${Date.now()}-${__VU}-${__ITER}`;
+  return `${Date.now()}-${exec.vu.idInTest}-${exec.scenario.iterationInTest}`;
 }
 
 function query(params) {

--- a/k6/scenarios/load-test.js
+++ b/k6/scenarios/load-test.js
@@ -1,0 +1,61 @@
+import { buildSummary } from './summary.js';
+import {
+  completePloggingWrite,
+  config,
+  getMonthlyStats,
+  getMyInfo,
+  getMyPloggingStats,
+  getNearbyToilets,
+  getNearbyTrashBins,
+  getRouteRecommendation,
+  getWeeklyStats,
+  listPloggingSessions,
+  thinkTime,
+} from './common.js';
+
+export const options = {
+  summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+  stages: [
+    { duration: '2m', target: 5 },
+    { duration: '3m', target: 10 },
+    { duration: '3m', target: 20 },
+    { duration: '3m', target: 30 },
+    { duration: '2m', target: 0 },
+  ],
+  thresholds: {
+    checks: ['rate>0.95'],
+    http_req_failed: ['rate<0.01'],
+    'http_req_duration{type:read}': ['p(95)<1000', 'p(99)<2000'],
+    'http_req_duration{type:route}': ['p(95)<5000', 'p(99)<10000'],
+    'http_req_duration{type:write}': ['p(95)<2500'],
+  },
+};
+
+export default function () {
+  const roll = Math.random();
+
+  if (roll < 0.35) {
+    getNearbyTrashBins();
+    thinkTime(0.2);
+    getNearbyToilets();
+  } else if (roll < 0.55) {
+    getMyInfo();
+    getMyPloggingStats();
+  } else if (roll < 0.75) {
+    listPloggingSessions();
+    getMonthlyStats();
+    getWeeklyStats();
+  } else if (roll < 0.92) {
+    getRouteRecommendation();
+  } else if (config.includeWrite) {
+    completePloggingWrite();
+  } else {
+    getNearbyTrashBins();
+  }
+
+  thinkTime();
+}
+
+export function handleSummary(data) {
+  return buildSummary(data, 'load');
+}

--- a/k6/scenarios/smoke-test.js
+++ b/k6/scenarios/smoke-test.js
@@ -1,0 +1,63 @@
+import { group } from 'k6';
+import { buildSummary } from './summary.js';
+import {
+  completePloggingWrite,
+  getMonthlyStats,
+  getMyInfo,
+  getMyPloggingStats,
+  getNearbyToilets,
+  getNearbyTrashBins,
+  getPloggingSessionDetail,
+  getRouteRecommendation,
+  getUploadUrlsSmoke,
+  getWeeklyStats,
+  listPloggingSessions,
+  thinkTime,
+} from './common.js';
+
+export const options = {
+  summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+  vus: 1,
+  duration: '1m',
+  thresholds: {
+    checks: ['rate>0.95'],
+    http_req_failed: ['rate<0.01'],
+    'http_req_duration{type:read}': ['p(95)<1000', 'p(99)<2000'],
+    'http_req_duration{type:route}': ['p(95)<5000'],
+    'http_req_duration{type:presigned_url}': ['p(95)<1500'],
+    'http_req_duration{type:write}': ['p(95)<2000'],
+  },
+};
+
+export default function () {
+  group('P0 public read APIs', () => {
+    getNearbyTrashBins();
+    thinkTime(0.5);
+    getNearbyToilets();
+    thinkTime(0.5);
+    getRouteRecommendation();
+  });
+
+  group('P0 authenticated read APIs', () => {
+    getMyInfo();
+    getMyPloggingStats();
+    listPloggingSessions();
+    getMonthlyStats();
+    getWeeklyStats();
+    getPloggingSessionDetail();
+  });
+
+  group('P1 presigned URL smoke only', () => {
+    getUploadUrlsSmoke();
+  });
+
+  group('P0 write API opt-in', () => {
+    completePloggingWrite();
+  });
+
+  thinkTime();
+}
+
+export function handleSummary(data) {
+  return buildSummary(data, 'smoke');
+}

--- a/k6/scenarios/stress-test.js
+++ b/k6/scenarios/stress-test.js
@@ -1,0 +1,61 @@
+import { buildSummary } from './summary.js';
+import {
+  completePloggingWrite,
+  config,
+  getMonthlyStats,
+  getMyInfo,
+  getMyPloggingStats,
+  getNearbyToilets,
+  getNearbyTrashBins,
+  getRouteRecommendation,
+  getWeeklyStats,
+  listPloggingSessions,
+  thinkTime,
+} from './common.js';
+
+export const options = {
+  summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+  stages: [
+    { duration: '2m', target: 10 },
+    { duration: '3m', target: 20 },
+    { duration: '3m', target: 30 },
+    { duration: '3m', target: 50 },
+    { duration: '2m', target: 0 },
+  ],
+  thresholds: {
+    checks: ['rate>0.90'],
+    http_req_failed: ['rate<0.05'],
+    'http_req_duration{type:read}': ['p(95)<2000', 'p(99)<5000'],
+    'http_req_duration{type:route}': ['p(95)<10000', 'p(99)<15000'],
+    'http_req_duration{type:write}': ['p(95)<4000'],
+  },
+};
+
+export default function () {
+  const roll = Math.random();
+
+  if (roll < 0.42) {
+    getNearbyTrashBins();
+  } else if (roll < 0.55) {
+    getNearbyToilets();
+  } else if (roll < 0.70) {
+    getMyInfo();
+    getMyPloggingStats();
+  } else if (roll < 0.85) {
+    listPloggingSessions();
+    getMonthlyStats();
+    getWeeklyStats();
+  } else if (roll < 0.98) {
+    getRouteRecommendation();
+  } else if (config.includeWrite) {
+    completePloggingWrite();
+  } else {
+    getNearbyTrashBins();
+  }
+
+  thinkTime(0.5);
+}
+
+export function handleSummary(data) {
+  return buildSummary(data, 'stress');
+}

--- a/k6/scenarios/summary.js
+++ b/k6/scenarios/summary.js
@@ -1,0 +1,129 @@
+function valueOf(data, metricName, valueName) {
+  const metric = data.metrics[metricName];
+  if (!metric || !metric.values) {
+    return null;
+  }
+  return metric.values[valueName] ?? null;
+}
+
+function formatNumber(value, digits = 2) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return 'n/a';
+  }
+  return Number(value).toFixed(digits);
+}
+
+function formatPercent(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return 'n/a';
+  }
+  return `${(Number(value) * 100).toFixed(2)}%`;
+}
+
+function thresholdRows(data) {
+  return Object.entries(data.metrics)
+    .filter(([, metric]) => metric.thresholds)
+    .flatMap(([name, metric]) => Object.entries(metric.thresholds)
+      .map(([threshold, result]) => `
+        <tr>
+          <td>${name}</td>
+          <td>${threshold}</td>
+          <td class="${result.ok ? 'pass' : 'fail'}">${result.ok ? 'PASS' : 'FAIL'}</td>
+        </tr>
+      `))
+    .join('');
+}
+
+function metricRow(data, label, metricName) {
+  return `
+    <tr>
+      <td>${label}</td>
+      <td>${formatNumber(valueOf(data, metricName, 'avg'))} ms</td>
+      <td>${formatNumber(valueOf(data, metricName, 'p(95)'))} ms</td>
+      <td>${formatNumber(valueOf(data, metricName, 'p(99)'))} ms</td>
+      <td>${formatNumber(valueOf(data, metricName, 'max'))} ms</td>
+    </tr>
+  `;
+}
+
+function renderHtml(data, testName) {
+  const failedRate = valueOf(data, 'http_req_failed', 'rate');
+  const requestRate = valueOf(data, 'http_reqs', 'rate');
+  const requestCount = valueOf(data, 'http_reqs', 'count');
+  const p95 = valueOf(data, 'http_req_duration', 'p(95)');
+  const p99 = valueOf(data, 'http_req_duration', 'p(99)');
+
+  return `<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <title>k6 ${testName} summary</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 32px; color: #1f2937; }
+    h1 { margin-bottom: 8px; }
+    table { border-collapse: collapse; width: 100%; margin-top: 16px; }
+    th, td { border: 1px solid #d1d5db; padding: 8px 10px; text-align: left; }
+    th { background: #f3f4f6; }
+    .metric-grid { display: grid; grid-template-columns: repeat(5, minmax(120px, 1fr)); gap: 12px; margin-top: 20px; }
+    .metric { border: 1px solid #d1d5db; border-radius: 6px; padding: 12px; }
+    .label { color: #6b7280; font-size: 12px; }
+    .value { font-size: 22px; margin-top: 6px; }
+    .pass { color: #047857; font-weight: 700; }
+    .fail { color: #b91c1c; font-weight: 700; }
+  </style>
+</head>
+<body>
+  <h1>k6 ${testName} summary</h1>
+  <p>발표용 핵심 지표: 실패율, p95/p99 응답 시간, 처리량(TPS/RPS), threshold 통과 여부</p>
+  <div class="metric-grid">
+    <div class="metric"><div class="label">http_req_failed</div><div class="value">${formatPercent(failedRate)}</div></div>
+    <div class="metric"><div class="label">http_req_duration p95</div><div class="value">${formatNumber(p95)} ms</div></div>
+    <div class="metric"><div class="label">http_req_duration p99</div><div class="value">${formatNumber(p99)} ms</div></div>
+    <div class="metric"><div class="label">TPS/RPS</div><div class="value">${formatNumber(requestRate)} req/s</div></div>
+    <div class="metric"><div class="label">Total requests</div><div class="value">${formatNumber(requestCount, 0)}</div></div>
+  </div>
+  <h2>Latency by Type</h2>
+  <table>
+    <thead><tr><th>Type</th><th>Avg</th><th>p95</th><th>p99</th><th>Max</th></tr></thead>
+    <tbody>
+      ${metricRow(data, 'overall', 'http_req_duration')}
+      ${metricRow(data, 'read', 'http_req_duration{type:read}')}
+      ${metricRow(data, 'route', 'http_req_duration{type:route}')}
+      ${metricRow(data, 'write', 'http_req_duration{type:write}')}
+    </tbody>
+  </table>
+  <h2>Thresholds</h2>
+  <table>
+    <thead><tr><th>Metric</th><th>Threshold</th><th>Result</th></tr></thead>
+    <tbody>${thresholdRows(data)}</tbody>
+  </table>
+</body>
+</html>`;
+}
+
+function renderStdout(data, testName) {
+  const failedRate = valueOf(data, 'http_req_failed', 'rate');
+  const requestRate = valueOf(data, 'http_reqs', 'rate');
+  const p95 = valueOf(data, 'http_req_duration', 'p(95)');
+  const p99 = valueOf(data, 'http_req_duration', 'p(99)');
+
+  return [
+    '',
+    `k6 ${testName} summary`,
+    `- http_req_failed: ${formatPercent(failedRate)}`,
+    `- http_req_duration p95: ${formatNumber(p95)} ms`,
+    `- http_req_duration p99: ${formatNumber(p99)} ms`,
+    `- route p95/p99: ${formatNumber(valueOf(data, 'http_req_duration{type:route}', 'p(95)'))} / ${formatNumber(valueOf(data, 'http_req_duration{type:route}', 'p(99)'))} ms`,
+    `- TPS/RPS(http_reqs rate): ${formatNumber(requestRate)} req/s`,
+    `- JSON/HTML saved under k6/results/${testName}-summary.*`,
+    '',
+  ].join('\n');
+}
+
+export function buildSummary(data, testName) {
+  return {
+    [`k6/results/${testName}-summary.json`]: JSON.stringify(data, null, 2),
+    [`k6/results/${testName}-summary.html`]: renderHtml(data, testName),
+    stdout: renderStdout(data, testName),
+  };
+}

--- a/src/main/java/com/plover/plover_be/route/client/RouteEngineClient.java
+++ b/src/main/java/com/plover/plover_be/route/client/RouteEngineClient.java
@@ -20,16 +20,20 @@ import java.util.Collections;
 @Component
 public class RouteEngineClient {
 
-    private static final int MAX_RETRIES = 3;
+    private static final int MAX_RETRIES = 2;
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
+    private static final long RETRY_DELAY_MILLIS = 300L;
+
     private final RestClient restClient;
 
     public RouteEngineClient(@Value("${route.engine.url}") String routeEngineUrl) {
         HttpClient httpClient = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(5))
+                .connectTimeout(CONNECT_TIMEOUT)
                 .build();
 
         JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
-        requestFactory.setReadTimeout(Duration.ofSeconds(15));
+        requestFactory.setReadTimeout(READ_TIMEOUT);
 
         this.restClient = RestClient.builder()
                 .baseUrl(routeEngineUrl)
@@ -41,7 +45,7 @@ public class RouteEngineClient {
         Exception lastException = null;
         for (int i = 0; i < MAX_RETRIES; i++) {
             try {
-                log.info("Requesting routes from engine (Attempt {}): lat={}, lon={}, distance={}",
+                log.debug("Requesting routes from engine (Attempt {}): lat={}, lon={}, distance={}",
                         i + 1, lat, lon, distance);
                 RouteDto.RouteInfo[] routeInfos = restClient.get()
                         .uri(uriBuilder -> uriBuilder
@@ -62,7 +66,7 @@ public class RouteEngineClient {
                 lastException = e;
                 if (i < MAX_RETRIES - 1) {
                     try {
-                        Thread.sleep(1000);
+                        Thread.sleep(RETRY_DELAY_MILLIS);
                     } catch (InterruptedException ie) {
                         Thread.currentThread().interrupt();
                         throw new RouteException(RouteErrorCode.ROUTE_CALCULATION_FAILED);


### PR DESCRIPTION
## 관련 이슈
  - close #71 

 ## 작업 내용                                                   
                                                                 
  - k6 기반 부하 테스트 구성을 추가했습니다.                     
      - smoke-test.js: 핵심 API 정상 호출 확인                   
      - load-test.js: 30 VU까지 점진 증가하는 일반 부하 테스트   
      - stress-test.js: 50 VU까지 증가시키는 한계 탐색 테스트    
      - ai-analysis-smoke-test.js: 외부 AI 분석 API 분리 테스트  
                                                                 
  - 운영 DB 오염 방지를 위해 쓰기/삭제/AI 호출을 기본 테스트에서 
    제외했습니다.                                                
      - DELETE /api/users/me 제외                                
      - 프로필/닉네임 변경 API 제외                              
      - POST /api/plogging-sessions/complete는 INCLUDE_WRITE=true
        일 때만 실행                                             
                                                                 
      - POST /api/plogging/analyze는 별도 스크립트와             
        RUN_HEAVY_API=true 필요                                  
                                                                                                                                  
  - route engine 호출의 꼬리 지연 완화를 위해 timeout/retry/log  
    level을 조정했습니다.                                        
      - retry 3회 -> 2회                                         
      - connect timeout 5초 -> 2초                               
      - read timeout 15초 -> 5초                                 
      - retry delay 1000ms -> 300ms                              
      - route 요청 로그 info -> debug                            
                                                                 
  ## 배경                                                        
                                                                 
- t2.micro급 EC2 환경에서 핵심 API의 성능 한계와 병목 가능성을 확인하기 위해 k6 부하 테스트를 도입했습니다.                     
                                                                 
- 기존 테스트 결과에서 일반 조회 API는 안정적이었지만, stress test에서 route API의 p99가 크게 증가했습니다. 
- route API는 외부 route engine을 호출하므로, 과도한 timeout/retry와 요청 단위 info 로그가 꼬리 지연을 키울 수 있어 보수적으로 조정했습니다.  
                                                                 
 ## 테스트 결과                                                 
                                                                 
- 로컬에서 배포 서버(moong.co.kr) 대상으로 k6 테스트를 수행했습니다.                                                            
                                                                 
<img width="315" height="806" alt="image" src="https://github.com/user-attachments/assets/07a8e39c-d8bb-49eb-ae73-8ebf2df8c0b4" />
                               
                                                                 
- route API 별도 지표:                                           
                                                                 
<img width="512" height="233" alt="image" src="https://github.com/user-attachments/assets/ad1004c5-8d21-42b5-b254-7af2a5a660c8" />                 
                                                                 
  ## 검증                                                        
                                                                 
  - [x] RouteControllerTest 통과                                 
  - [x] k6 inspect 통과                                          
  - [x] k6 smoke/load/stress 테스트 실행                         
  - [x] 커밋 대상에 JWT, JWT_SECRET, DB/AWS/API 키 등 민감정보 없
    음                                                           
                                                                 
  ## 주의사항                                                    
                                                                 
  - k6 결과 파일은 k6/results/에 로컬 저장되지만 git에는 포함되지
    않습니다.                                                    
                                                                 
  - 운영 DB 오염 방지를 위해 기본 k6 실행에서는 쓰기/삭제 API를  
    호출하지 않습니다.                                           
                                                                 
  - INCLUDE_WRITE=true, RUN_HEAVY_API=true는 운영 서버 대상으로  
    실행하지 않는 것을 권장합니다.                               
                                                                 
  - route engine 튜닝 효과는 배포 후 stress test를 다시 실행해   
    route p99를 비교해야 합니다.           

## 테스트
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.

## 체크리스트
- [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.
- [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.
- [x] 머지 전 스스로 한 번 더 확인했습니다.
