### PR TITLE
feat: 라우팅 엔진 추론에 캐싱 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
 	implementation 'software.amazon.awssdk:s3:2.25.70'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/k6/README.md
+++ b/k6/README.md
@@ -142,12 +142,12 @@ AI 분석 테스트 이미지는 반드시 `k6/data/sample-trash-image.jpg` 경�
 각 스크립트는 종료 시 자동으로 결과를 저장합니다.
 
 ```text
-k6/results/smoke-summary.json
-k6/results/smoke-summary.html
-k6/results/load-summary.json
-k6/results/load-summary.html
-k6/results/stress-summary.json
-k6/results/stress-summary.html
+k6/results/smoke-summary-YYYYMMDD-HHmmss.json
+k6/results/smoke-summary-YYYYMMDD-HHmmss.html
+k6/results/load-summary-YYYYMMDD-HHmmss.json
+k6/results/load-summary-YYYYMMDD-HHmmss.html
+k6/results/stress-summary-YYYYMMDD-HHmmss.json
+k6/results/stress-summary-YYYYMMDD-HHmmss.html
 ```
 
 k6 기본 JSON export도 같이 남기고 싶다면 다음처럼 실행할 수 있습니다.

--- a/k6/scenarios/summary.js
+++ b/k6/scenarios/summary.js
@@ -20,6 +20,28 @@ function formatPercent(value) {
   return `${(Number(value) * 100).toFixed(2)}%`;
 }
 
+function pad2(value) {
+  return String(value).padStart(2, '0');
+}
+
+function formatTimestamp(date) {
+  const datePart = [
+    date.getFullYear(),
+    pad2(date.getMonth() + 1),
+    pad2(date.getDate()),
+  ].join('');
+  const timePart = [
+    pad2(date.getHours()),
+    pad2(date.getMinutes()),
+    pad2(date.getSeconds()),
+  ].join('');
+  return `${datePart}-${timePart}`;
+}
+
+function formatGeneratedAt(date) {
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())} local time`;
+}
+
 function thresholdRows(data) {
   return Object.entries(data.metrics)
     .filter(([, metric]) => metric.thresholds)
@@ -46,7 +68,7 @@ function metricRow(data, label, metricName) {
   `;
 }
 
-function renderHtml(data, testName) {
+function renderHtml(data, testName, generatedAt) {
   const failedRate = valueOf(data, 'http_req_failed', 'rate');
   const requestRate = valueOf(data, 'http_reqs', 'rate');
   const requestCount = valueOf(data, 'http_reqs', 'count');
@@ -57,10 +79,11 @@ function renderHtml(data, testName) {
 <html lang="ko">
 <head>
   <meta charset="utf-8">
-  <title>k6 ${testName} summary</title>
+  <title>k6 ${testName} summary - ${generatedAt}</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 32px; color: #1f2937; }
     h1 { margin-bottom: 8px; }
+    .generated-at { color: #6b7280; margin-top: 0; }
     table { border-collapse: collapse; width: 100%; margin-top: 16px; }
     th, td { border: 1px solid #d1d5db; padding: 8px 10px; text-align: left; }
     th { background: #f3f4f6; }
@@ -73,7 +96,8 @@ function renderHtml(data, testName) {
   </style>
 </head>
 <body>
-  <h1>k6 ${testName} summary</h1>
+  <h1>k6 ${testName} summary - ${generatedAt}</h1>
+  <p class="generated-at">Generated at: ${generatedAt}</p>
   <p>발표용 핵심 지표: 실패율, p95/p99 응답 시간, 처리량(TPS/RPS), threshold 통과 여부</p>
   <div class="metric-grid">
     <div class="metric"><div class="label">http_req_failed</div><div class="value">${formatPercent(failedRate)}</div></div>
@@ -101,7 +125,7 @@ function renderHtml(data, testName) {
 </html>`;
 }
 
-function renderStdout(data, testName) {
+function renderStdout(data, testName, timestamp) {
   const failedRate = valueOf(data, 'http_req_failed', 'rate');
   const requestRate = valueOf(data, 'http_reqs', 'rate');
   const p95 = valueOf(data, 'http_req_duration', 'p(95)');
@@ -115,15 +139,20 @@ function renderStdout(data, testName) {
     `- http_req_duration p99: ${formatNumber(p99)} ms`,
     `- route p95/p99: ${formatNumber(valueOf(data, 'http_req_duration{type:route}', 'p(95)'))} / ${formatNumber(valueOf(data, 'http_req_duration{type:route}', 'p(99)'))} ms`,
     `- TPS/RPS(http_reqs rate): ${formatNumber(requestRate)} req/s`,
-    `- JSON/HTML saved under k6/results/${testName}-summary.*`,
+    `- JSON/HTML saved under k6/results/${testName}-summary-${timestamp}.*`,
     '',
   ].join('\n');
 }
 
 export function buildSummary(data, testName) {
+  const generatedDate = new Date();
+  const timestamp = formatTimestamp(generatedDate);
+  const generatedAt = formatGeneratedAt(generatedDate);
+  const basePath = `k6/results/${testName}-summary-${timestamp}`;
+
   return {
-    [`k6/results/${testName}-summary.json`]: JSON.stringify(data, null, 2),
-    [`k6/results/${testName}-summary.html`]: renderHtml(data, testName),
-    stdout: renderStdout(data, testName),
+    [`${basePath}.json`]: JSON.stringify(data, null, 2),
+    [`${basePath}.html`]: renderHtml(data, testName, generatedAt),
+    stdout: renderStdout(data, testName, timestamp),
   };
 }

--- a/src/main/java/com/plover/plover_be/route/client/RouteEngineClient.java
+++ b/src/main/java/com/plover/plover_be/route/client/RouteEngineClient.java
@@ -17,11 +17,13 @@ import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Locale;
 
 @Slf4j
 @Component
 public class RouteEngineClient {
 
+    private static final String DEFAULT_MODE = "PLOGGING";
     private static final int MAX_RETRIES = 2;
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
     private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
@@ -51,8 +53,9 @@ public class RouteEngineClient {
     }
 
     public RouteDto.Response getRoute(double lat, double lon, int distance, String mode) {
-        RouteCacheKey key = RouteCacheKey.from(lat, lon, distance, mode);
-        return routeCache.get(key, ignored -> requestRouteFromEngine(lat, lon, distance, mode));
+        String normalizedMode = normalizeMode(mode);
+        RouteCacheKey key = RouteCacheKey.from(lat, lon, distance, normalizedMode);
+        return routeCache.get(key, ignored -> requestRouteFromEngine(lat, lon, distance, normalizedMode));
     }
 
     private RouteDto.Response requestRouteFromEngine(double lat, double lon, int distance, String mode) {
@@ -90,6 +93,13 @@ public class RouteEngineClient {
         }
         log.error("All {} attempts failed for Route Engine API.", MAX_RETRIES, lastException);
         throw new RouteException(RouteErrorCode.ROUTE_ENGINE_CONNECTION_FAILED);
+    }
+
+    private String normalizeMode(String mode) {
+        if (mode == null || mode.isBlank()) {
+            return DEFAULT_MODE;
+        }
+        return mode.trim().toUpperCase(Locale.ROOT);
     }
 
     private record RouteCacheKey(long latBucket, long lonBucket, int distance, String mode) {

--- a/src/main/java/com/plover/plover_be/route/client/RouteEngineClient.java
+++ b/src/main/java/com/plover/plover_be/route/client/RouteEngineClient.java
@@ -1,5 +1,7 @@
 package com.plover.plover_be.route.client;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.plover.plover_be.route.dto.RouteDto;
 import com.plover.plover_be.route.exception.RouteErrorCode;
 import com.plover.plover_be.route.exception.RouteException;
@@ -24,8 +26,15 @@ public class RouteEngineClient {
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
     private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
     private static final long RETRY_DELAY_MILLIS = 300L;
+    private static final double COORDINATE_BUCKET_SIZE = 0.0005;
+    private static final long ROUTE_CACHE_MAX_SIZE = 1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Duration.ofMinutes(5);
 
     private final RestClient restClient;
+    private final Cache<RouteCacheKey, RouteDto.Response> routeCache = Caffeine.newBuilder()
+            .maximumSize(ROUTE_CACHE_MAX_SIZE)
+            .expireAfterWrite(ROUTE_CACHE_TTL)
+            .build();
 
     public RouteEngineClient(@Value("${route.engine.url}") String routeEngineUrl) {
         HttpClient httpClient = HttpClient.newBuilder()
@@ -42,6 +51,11 @@ public class RouteEngineClient {
     }
 
     public RouteDto.Response getRoute(double lat, double lon, int distance, String mode) {
+        RouteCacheKey key = RouteCacheKey.from(lat, lon, distance, mode);
+        return routeCache.get(key, ignored -> requestRouteFromEngine(lat, lon, distance, mode));
+    }
+
+    private RouteDto.Response requestRouteFromEngine(double lat, double lon, int distance, String mode) {
         Exception lastException = null;
         for (int i = 0; i < MAX_RETRIES; i++) {
             try {
@@ -76,5 +90,16 @@ public class RouteEngineClient {
         }
         log.error("All {} attempts failed for Route Engine API.", MAX_RETRIES, lastException);
         throw new RouteException(RouteErrorCode.ROUTE_ENGINE_CONNECTION_FAILED);
+    }
+
+    private record RouteCacheKey(long latBucket, long lonBucket, int distance, String mode) {
+
+        private static RouteCacheKey from(double lat, double lon, int distance, String mode) {
+            return new RouteCacheKey(toBucket(lat), toBucket(lon), distance, mode);
+        }
+
+        private static long toBucket(double coordinate) {
+            return Math.round(coordinate / COORDINATE_BUCKET_SIZE);
+        }
     }
 }

--- a/src/test/java/com/plover/plover_be/route/client/RouteEngineClientTest.java
+++ b/src/test/java/com/plover/plover_be/route/client/RouteEngineClientTest.java
@@ -1,0 +1,104 @@
+package com.plover.plover_be.route.client;
+
+import com.plover.plover_be.route.dto.RouteDto;
+import com.plover.plover_be.route.exception.RouteException;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouteEngineClientTest {
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @DisplayName("비슷한 좌표의 성공 응답은 캐시되어 route engine을 한 번만 호출한다")
+    @Test
+    void get_route_caches_success_response_for_nearby_coordinates() throws IOException {
+        // given
+        AtomicInteger callCount = new AtomicInteger();
+        RouteEngineClient client = createClient(exchange -> {
+            callCount.incrementAndGet();
+            respond(exchange, 200, routeResponseBody());
+        });
+
+        // when
+        RouteDto.Response first = client.getRoute(37.5665, 126.9780, 2500, "PLOGGING");
+        RouteDto.Response second = client.getRoute(37.56651, 126.97802, 2500, "PLOGGING");
+
+        // then
+        assertThat(first.routes()).hasSize(1);
+        assertThat(second.routes()).hasSize(1);
+        assertThat(callCount.get()).isEqualTo(1);
+    }
+
+    @DisplayName("route engine 실패 응답은 캐시하지 않는다")
+    @Test
+    void get_route_does_not_cache_failure_response() throws IOException {
+        // given
+        AtomicInteger callCount = new AtomicInteger();
+        RouteEngineClient client = createClient(exchange -> {
+            int currentCount = callCount.incrementAndGet();
+            if (currentCount <= 2) {
+                respond(exchange, 500, "{\"message\":\"error\"}");
+                return;
+            }
+            respond(exchange, 200, routeResponseBody());
+        });
+
+        // when & then
+        assertThatThrownBy(() -> client.getRoute(37.5665, 126.9780, 2500, "PLOGGING"))
+                .isInstanceOf(RouteException.class);
+
+        RouteDto.Response response = client.getRoute(37.5665, 126.9780, 2500, "PLOGGING");
+
+        assertThat(response.routes()).hasSize(1);
+        assertThat(callCount.get()).isEqualTo(3);
+    }
+
+    private RouteEngineClient createClient(HttpHandler handler) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/api/v1/route", handler);
+        server.start();
+        return new RouteEngineClient("http://localhost:" + server.getAddress().getPort());
+    }
+
+    private void respond(HttpExchange exchange, int statusCode, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream outputStream = exchange.getResponseBody()) {
+            outputStream.write(bytes);
+        }
+    }
+
+    private String routeResponseBody() {
+        return """
+                [
+                  {
+                    "distanceMeter": 2500.0,
+                    "timeMillis": 605000,
+                    "encodedPath": "encodedPathData",
+                    "ploggingScore": 98
+                  }
+                ]
+                """;
+    }
+}

--- a/src/test/java/com/plover/plover_be/route/client/RouteEngineClientTest.java
+++ b/src/test/java/com/plover/plover_be/route/client/RouteEngineClientTest.java
@@ -14,6 +14,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -71,6 +72,29 @@ class RouteEngineClientTest {
 
         assertThat(response.routes()).hasSize(1);
         assertThat(callCount.get()).isEqualTo(3);
+    }
+
+    @DisplayName("mode는 기본값과 대문자로 정규화되어 캐시 키와 route engine 요청에 사용된다")
+    @Test
+    void get_route_normalizes_mode_for_cache_key_and_engine_request() throws IOException {
+        // given
+        AtomicInteger callCount = new AtomicInteger();
+        AtomicReference<String> rawQuery = new AtomicReference<>();
+        RouteEngineClient client = createClient(exchange -> {
+            callCount.incrementAndGet();
+            rawQuery.set(exchange.getRequestURI().getRawQuery());
+            respond(exchange, 200, routeResponseBody());
+        });
+
+        // when
+        RouteDto.Response first = client.getRoute(37.5665, 126.9780, 2500, "plogging");
+        RouteDto.Response second = client.getRoute(37.5665, 126.9780, 2500, null);
+
+        // then
+        assertThat(first.routes()).hasSize(1);
+        assertThat(second.routes()).hasSize(1);
+        assertThat(callCount.get()).isEqualTo(1);
+        assertThat(rawQuery.get()).contains("mode=PLOGGING");
     }
 
     private RouteEngineClient createClient(HttpHandler handler) throws IOException {


### PR DESCRIPTION
 ## 관련 이슈                                                                                                                                                  
  - close #72                                                                                                                                     
                                                                                                                                                                
  ## 작업 내용                                                                                                                                                  
  - route engine API 호출 결과에 Caffeine 기반 인메모리 캐시를 적용했습니다.                                                                                    
  - `RouteEngineClient#getRoute()`에서 캐시 키를 생성한 뒤 `routeCache.get(key, ...)` 방식으로 캐시 조회 및 미스 시 route engine 호출을 수행하도록 변경했습니다.
  - 캐시 키는 다음 값으로 구성했습니다.                                                                                                                         
    - 위도 bucket                                                                                                                                               
    - 경도 bucket                                                                                                                                               
    - distance                                                                                                                                                  
    - mode                                                                                                                                                      
  - 위도/경도는 `0.0005도` 단위로 버킷화하여 GPS 오차 수준의 비슷한 좌표 요청이 같은 캐시를 사용할 수 있도록 했습니다.
  - 캐시 정책은 다음과 같이 설정했습니다.                                                                                                                       
    - 최대 엔트리 수: `1,000`                                                                                                                                   
    - TTL: `5분`                                                                                                                                                
  - route engine 호출이 성공적으로 응답한 경우에만 캐시됩니다.                                                                                                  
    - route engine 실패, timeout, 5xx 등으로 예외가 발생하면 캐시에 저장되지 않습니다.                                                                          
  - k6 summary 결과 파일명이 매 실행마다 덮어써지지 않도록 타임스탬프를 포함하도록 개선했습니다.                                                                
    - 예: `stress-summary-YYYYMMDD-HHmmss.json`                                                                                                                 
    - 예: `stress-summary-YYYYMMDD-HHmmss.html`                                                                                                                 
  - README의 k6 결과 파일명 예시도 실제 생성 규칙에 맞게 수정했습니다.                                                                                          
                                                                                                                                                                
  ## 테스트                                                                                                                                                     
  - [x] 로컬에서 정상 동작을 확인했습니다.                                                                                                                      
  - [x] 관련 테스트를 추가했거나 기존 테스트를 통과했습니다.                                                                                                    
                                                                                                                                                                
  ### 테스트 상세                                                                                                                                               
  - `RouteEngineClientTest` 추가                                                                                                                                
    - 비슷한 좌표로 2번 요청했을 때 route engine은 1번만 호출되고 두 번째 요청은 캐시를 사용하는지 검증했습니다.                                                
    - route engine 실패 응답은 캐시하지 않고, 이후 요청에서 다시 route engine을 호출하는지 검증했습니다.                                                        
  - 실행한 테스트                                                                                                                                               
    - `.\gradlew.bat test --tests "com.plover.plover_be.route.client.RouteEngineClientTest"`                                                                    
    - `.\gradlew.bat test`                                                                                                                                      
                                                                                                                                                                
  ## 체크리스트                                                                                                                                                 
  - [x] 관련 없는 변경이나 내용은 포함하지 않았습니다.                                                                                                          
  - [x] 리뷰어가 이해할 수 있도록 필요한 설명을 작성했습니다.                                                                                                   
  - [x] 머지 전 스스로 한 번 더 확인했습니다.                            